### PR TITLE
launch with dedicated gpu desktop entry patch

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -142,6 +142,7 @@ source=("$_winesrcdir"::"git://source.winehq.org/git/wine.git${_plain_commit}"
 		'PBA314+.patch'
 		'fallout4.patch'
 		'fortnite.patch'
+		'launch-with-dedicated-gpu-desktop-entry.patch'
 		'lowlatency_audio.patch'
 		'dxvk-winelib.patch')
 
@@ -465,6 +466,12 @@ prepare() {
 	  fi
 	fi
 
+	# Launch with dedicated gpu desktop entry patch
+	if [ $_launch_with_dedicated_gpu == "true" ]; then
+	  patch -Np1 < ../'launch-with-dedicated-gpu-desktop-entry.patch'
+	  echo "Applied launch with dedicated gpu desktop entry patch" >> $_where/last_build_config.log
+	fi
+
 	# Low latency alsa audio - https://blog.thepoon.fr/osuLinuxAudioLatency/
 	if [ $_lowlatency_audio == "true" ] && [ $_use_staging == "true" ]; then
 	  patch -Np1 < ../'lowlatency_audio.patch'
@@ -663,6 +670,7 @@ md5sums=('SKIP'
          '940475a482b411ed7111022175df03c1'
          'd1a18945f2ca46fa3fce70e157393a01'
          'f50501943759c8731d40eb521e36e6da'
+         '78ea7fa80abd8beb6e2afac27deb938f'
          'ed6060dc030ebd5865f1fcc40d8863be'
          'd328bfd0d363434fe5f83f3a614849f7')
 

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -84,6 +84,9 @@ _steam_fix="true"
 # low latency alsa patch - Requires staging - https://blog.thepoon.fr/osuLinuxAudioLatency/
 _lowlatency_audio="false"
 
+# launch with dedicated gpu desktop entry patch - makes an additional desktop entry which launches app with DRI_PRIME set to 1 (only for switchable graphics with mesa drivers)
+_launch_with_dedicated_gpu="false"
+
 
 #### USER PATCHES ####
 

--- a/wine-tkg-git/launch-with-dedicated-gpu-desktop-entry.patch
+++ b/wine-tkg-git/launch-with-dedicated-gpu-desktop-entry.patch
@@ -1,0 +1,68 @@
+From ae3db1317289547a555412bc5a82d44ae5ecf503 Mon Sep 17 00:00:00 2001
+From: Martin Otto <paraboloid234@gmail.com>
+Date: Mon, 10 Sep 2018 17:28:33 +0200
+Subject: [PATCH] loader: add launch with dedicated gpu desktop entry
+
+---
+ configure                         | 2 +-
+ configure.ac                      | 2 +-
+ loader/Makefile.in                | 1 +
+ loader/wine_dedicated_gpu.desktop | 8 ++++++++
+ 4 files changed, 11 insertions(+), 2 deletions(-)
+ create mode 100644 loader/wine_dedicated_gpu.desktop
+
+diff --git a/configure b/configure
+index a3916ee..84b4388 100755
+--- a/configure
++++ b/configure
+@@ -20197,7 +20197,7 @@ else
+ 
+     case $host_os in
+       cygwin*|mingw32*|darwin*|macosx*|linux-android*) ;;
+-      *) WINELOADER_INSTALL="$WINELOADER_INSTALL wine.desktop" ;;
++      *) WINELOADER_INSTALL="$WINELOADER_INSTALL wine.desktop wine_dedicated_gpu.desktop" ;;
+     esac
+ fi
+ 
+diff --git a/configure.ac b/configure.ac
+index 006f7d9..e82d3c3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4068,7 +4068,7 @@ else
+     AC_SUBST(WINELOADER_INSTALL,"wine.inf l_intl.nls")
+     case $host_os in
+       cygwin*|mingw32*|darwin*|macosx*|linux-android*) ;;
+-      *) WINELOADER_INSTALL="$WINELOADER_INSTALL wine.desktop" ;;
++      *) WINELOADER_INSTALL="$WINELOADER_INSTALL wine.desktop wine_dedicated_gpu.desktop" ;;
+     esac
+ fi
+ 
+diff --git a/loader/Makefile.in b/loader/Makefile.in
+index b1eafd1..4b5f467 100644
+--- a/loader/Makefile.in
++++ b/loader/Makefile.in
+@@ -4,6 +4,7 @@ SOURCES = \
+ 	preloader.c \
+ 	wine.de.UTF-8.man.in \
+ 	wine.desktop \
++	wine_dedicated_gpu.desktop \
+ 	wine.fr.UTF-8.man.in \
+ 	wine.inf.in \
+ 	wine.man.in \
+diff --git a/loader/wine_dedicated_gpu.desktop b/loader/wine_dedicated_gpu.desktop
+new file mode 100644
+index 0000000..9e859d6
+--- /dev/null
++++ b/loader/wine_dedicated_gpu.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Type=Application
++Name=Wine Windows Program Loader (Dedicated GPU)
++Exec=env DRI_PRIME=1 wine start /unix %f
++MimeType=application/x-ms-dos-executable;application/x-msi;application/x-ms-shortcut;
++Icon=wine
++NoDisplay=true
++StartupNotify=true
+-- 
+2.18.0
+


### PR DESCRIPTION
Hello,

would you consider adding this small patch? Does a favor for users that have laptop with switchable graphics and mesa drivers, will make an additional desktop entry which runs wine with DRI_PRIME set to 1 so it is not necessary to always set this variable via e.g. command line to make it run on dedicated gpu.

Thank you.