### PR TITLE
Added ccache to makedepends

### DIFF
--- a/linux418-tkg/PKGBUILD
+++ b/linux418-tkg/PKGBUILD
@@ -31,7 +31,7 @@ pkgrel=29
 arch=('x86_64') # no i686 in here
 url="http://www.kernel.org/"
 license=('GPL2')
-makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'elfutils' 'schedtool' 'patchutils' 'flex')
+makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'elfutils' 'schedtool' 'patchutils' 'flex' 'ccache')
 options=('!strip' 'ccache' 'makeflags')
 source=("https://www.kernel.org/pub/linux/kernel/v4.x/linux-${_basekernel}.tar.xz"
         "https://www.kernel.org/pub/linux/kernel/v4.x/patch-${pkgver}.xz"


### PR DESCRIPTION
Running `makepkg -s` without ccache installed gives a missing executable error