### PR TITLE
Improvements to wine-tkg-git

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -183,7 +183,7 @@ optdepends=(
 source=("$_winesrcdir"::"git://source.winehq.org/git/wine.git${_plain_commit}"
 		"$_stgsrcdir"::"git+https://github.com/wine-staging/wine-staging.git${_staging_commit}"
 		"$_dxvksrcdir"::"git+https://github.com/doitsujin/dxvk.git${_dxvk_commit}"
-		"https://github.com/zfigura/wine/releases/download/esync${_esync_version}/esync.tgz"
+		"esync${_esync_version}.tgz::https://github.com/zfigura/wine/releases/download/esync${_esync_version}/esync.tgz"
 		# game specific
 		'poe-fix.patch'
 		'f4skyrimse-fix.patch'
@@ -623,7 +623,6 @@ prepare() {
 
 	# no compilation
 	if [ $_NOCOMPILE == "true" ]; then
-	  rm -fv $_where/esync.tgz # User may want to switch esync releases. Better nuke it to stay fresh
 	  msg2 'make prepare function fail by using Gandalf'
 	  YOU_SHALL_NOT_PASS
 	fi
@@ -735,7 +734,6 @@ package() {
 	rm -fv $_where/BIG_UGLY_COINMINER # state tracker end
 
 	if [ $_NUKR == "true" ]; then
-	  rm -fv $_where/esync.tgz # User may want to switch esync releases. Better nuke it to stay fresh
 	  rm -rf $srcdir # Nuke the entire src folder so it'll get regenerated clean on next build
 	  msg2 'srcdir was nuked. See ya !'
 	fi
@@ -784,4 +782,4 @@ md5sums=('SKIP'
          'bccedecbf4ccb527552ba52a24315f71')
 
 # Remove the state tracker on failed/stopped compilation
-trap "{ rm -f $_where/BIG_UGLY_COINMINER; rm -f $_where/esync.tgz; }" EXIT
+trap "{ rm -f $_where/BIG_UGLY_COINMINER; }" EXIT

--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -67,11 +67,6 @@ if [[ $_use_dxvk == "true" ]]; then
   msg2 "Using DXVK winelib for d3d10 and d3d11 translation"
 fi
 
-if [[ $_lowlatency_audio == "true" ]]; then
-  pkgname="${pkgname/%-git/-osu-git}"
-  msg2 "Using low latency audio patch"
-fi
-
 if [[ $_OPTIMIZED == "true" ]]; then
   pkgname="${pkgname/%-git/-optimized-git}"
   msg2 "Using native processor optimizations"

--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -154,6 +154,9 @@ makedepends=('git' 'autoconf' 'ncurses' 'bison' 'perl' 'fontforge' 'flex'
     'meson'                 'ninja'
     'glslang'
 )
+if [[ $_use_dxvk == true ]]; then
+  makedepends=("${makedepends[@]}" wine)
+fi
 optdepends=(
     'giflib'                'lib32-giflib'
     'libpng'                'lib32-libpng'

--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -100,7 +100,7 @@ pkgdesc='This "Wine to rule them all" package is the result of some random pkgbu
 url='https://github.com/Tk-Glitch/PKGBUILDS/tree/master/wine-tkg-git'
 arch=('x86_64')
 
-if [ $(pacman -Qs ccache | head -c1 | wc -c) -eq 1 ]; then
+if pacman -Qq ccache &> /dev/null; then
   msg2 'ccache was found and will be used'
   options=('staticlibs' 'ccache')
 else

--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -72,6 +72,11 @@ if [[ $_lowlatency_audio == "true" ]]; then
   msg2 "Using low latency audio patch"
 fi
 
+if [[ $_OPTIMIZED == "true" ]]; then
+  pkgname="${pkgname/%-git/-optimized-git}"
+  msg2 "Using native processor optimizations"
+fi
+
 # custom plain wine commit to pass to git
 if [ $_use_staging == "false" ] && [ -n "$_plain_version" ]; then
   _plain_commit="#commit=$_plain_version"

--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Created by: Tk-Glitch <ti3nou at gmail dot com>
 
 pkgname=wine-tkg-git
-pkgver=3.18.r0.g30dca36a.staging.esync.pba
+pkgver=3.18.r0.g30dca36a
 pkgrel=67
 _winesrcdir='wine-git'
 _stgsrcdir='wine-staging-git'
@@ -35,6 +35,36 @@ else
 
     source $_where/customization.cfg # load configuration from file again, in case of changes.
   fi
+fi
+
+if [[ $_use_staging == "true" ]]; then
+  pkgname="${pkgname/%-git/-staging-git}"
+  msg2 "Using staging patchset"
+fi
+
+if [[ $_use_esync == "true" ]]; then
+  pkgname="${pkgname/%-git/-esync-git}"
+  msg2 "Using esync (${_esync_version}) patchset"
+fi
+
+if [[ $_use_pba == "true" ]]; then
+  pkgname="${pkgname/%-git/-pba-git}"
+  msg2 "Using pba patchset"
+fi
+
+if [[ $_use_gallium_nine == "true" ]]; then
+  pkgname="${pkgname/%-git/-nine-git}"
+  msg2 "Using gallium nine patchset"
+fi
+
+if [[ $_use_vkd3d == "true" ]]; then
+  pkgname="${pkgname/%-git/-vkd3d-git}"
+  msg2 "Using VKD3D for d3d12 translation"
+fi
+
+if [[ $_use_dxvk == "true" ]]; then
+  pkgname="${pkgname/%-git/-dxvk-git}"
+  msg2 "Using DXVK winelib for d3d10 and d3d11 translation"
 fi
 
 # custom plain wine commit to pass to git
@@ -221,43 +251,13 @@ user_patcher() {
 
 pkgver() {
 	if [ $_use_staging == "true" ]; then
-	  _stg=".staging"
-	  msg2 "Using staging patchset"
 	  cd "${srcdir}/${_stgsrcdir}"
 	else
 	  cd "${srcdir}/${_winesrcdir}"
 	fi
 
-	if [ $_use_esync == "true" ]; then
-	  _zf=".esync"
-	  msg2 "Using esync (${_esync_version}) patchset"
-	fi
-
-	if [ $_use_pba == "true" ]; then
-	  _firerat=".pba"
-	  msg2 "Using pba (${_pba_version}) patchset"
-	fi
-
-	if [ $_use_gallium_nine == "true" ]; then
-	  _nine=".nine"
-	  msg2 "Using gallium nine patchset"
-	fi
-
-	if [ $_use_vkd3d == "true" ]; then
-	  _vkd3d=".vkd3d"
-	  msg2 "Using VKD3D for d3d12 translation"
-	fi
-
-	if [ $_use_dxvk == "true" ]; then
-	  _doitsujin=".dxvk"
-	  msg2 "Using DXVK winelib for d3d10 and d3d11 translation"
-	fi
-
 	# retrieve current wine version - if staging is enabled, staging version will be used instead
-	local _wineVer="$(git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//;s/\.rc/rc/')"
-
-	# version string
-	printf '%s%s%s%s%s%s%s' "${_wineVer#wine.}" "$_stg" "$_zf" "$_firerat" "$_nine" "$_vkd3d" "$_doitsujin"
+	git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//;s/\.rc/rc/;s/^wine\.//'
 }
 
 prepare() {
@@ -656,7 +656,7 @@ build() {
 		$_withd3d9nine \
 		$_withvkd3d \
 		--with-wine64="${srcdir}/${pkgname}"-64-build \
-		#--disable-tests 
+		#--disable-tests
 
     # make using all available threads
 	schedtool -B -n 1 -e ionice -n 1 make -j$(nproc)
@@ -679,14 +679,14 @@ package() {
 	make 	prefix="${pkgdir}/usr" \
 			libdir="${pkgdir}/usr/lib32" \
 			dlldir="${pkgdir}/usr/lib32/wine" install
-	
+
 	# package wine 64-bit
 	msg2 'Packaging Wine-64...'
 	cd "${srcdir}/${pkgname}"-64-build
 	make 	prefix="${pkgdir}/usr" \
 			libdir="${pkgdir}/usr/lib" \
 			dlldir="${pkgdir}/usr/lib/wine" install
-	
+
 	# freetype font smoothing for win32 applications
 	install -d "$pkgdir"/etc/fonts/conf.{avail,d}
 	install -m644 "${srcdir}/30-win32-aliases.conf" "${pkgdir}/etc/fonts/conf.avail"

--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -77,6 +77,10 @@ if [[ $_OPTIMIZED == "true" ]]; then
   msg2 "Using native processor optimizations"
 fi
 
+if [[ $_INSTALL_TO_OPT == "true" ]]; then
+  msg2 "Installing to /opt/$pkgname"
+fi
+
 # custom plain wine commit to pass to git
 if [ $_use_staging == "false" ] && [ -n "$_plain_version" ]; then
   _plain_commit="#commit=$_plain_version"
@@ -208,14 +212,15 @@ source=("$_winesrcdir"::"git://source.winehq.org/git/wine.git${_plain_commit}"
 		'dxvk-winelib.patch'
 		'winevulkan_transform-feedback_ext.patch')
 
-provides=(
-	"wine=$pkgver"
-	"wine-wow64=$pkgver"
-	"wine-staging=$pkgver"
-	"wine-esync=$pkgver"
-)
-
-conflicts=('wine' 'wine-wow64' 'wine-staging' 'wine-esync')
+if [[ $_INSTALL_TO_OPT != true ]]; then
+  provides=(
+    "wine=$pkgver"
+    "wine-wow64=$pkgver"
+    "wine-staging=$pkgver"
+    "wine-esync=$pkgver"
+  )
+  conflicts=('wine' 'wine-wow64' 'wine-staging' 'wine-esync')
+fi
 makedepends=(${makedepends[@]} ${depends[@]})
 install=wine.install
 
@@ -634,13 +639,18 @@ build() {
 
 	cd "${srcdir}"
 
+	local _prefix=/usr
+	if [[ $_INSTALL_TO_OPT == true ]]; then
+	  _prefix=/opt/$pkgname
+	fi
+
 	# build wine 64-bit
 	# (according to the wine wiki, this 64-bit/32-bit building order is mandatory)
 	msg2 'Building Wine-64...'
 	cd  "${srcdir}"/"${pkgname}"-64-build
 	../${_winesrcdir}/configure \
-		--prefix='/usr' \
-		--libdir='/usr/lib' \
+		--prefix="$_prefix" \
+		--libdir="$_prefix/lib" \
 		--with-x \
 		--with-gstreamer \
 		--enable-win64 \
@@ -658,8 +668,8 @@ build() {
 	msg2 'Building Wine-32...'
 	cd "${srcdir}/${pkgname}"-32-build
 	../${_winesrcdir}/configure \
-		--prefix='/usr' \
-		--libdir='/usr/lib32' \
+		--prefix="$_prefix" \
+		--libdir="$_prefix/lib32" \
 		--with-x \
 		--with-gstreamer \
 		--with-xattr \
@@ -682,33 +692,44 @@ build() {
 
 package() {
 
+	local _prefix=/usr
+	if [[ $_INSTALL_TO_OPT == true ]]; then
+	  _prefix=/opt/$pkgname
+	fi
+
 	# package wine 32-bit
 	# (according to the wine wiki, this reverse 32-bit/64-bit packaging order is important)
 	msg2 'Packaging Wine-32...'
 	cd "${srcdir}/${pkgname}"-32-build
-	make 	prefix="${pkgdir}/usr" \
-			libdir="${pkgdir}/usr/lib32" \
-			dlldir="${pkgdir}/usr/lib32/wine" install
+	make 	prefix="${pkgdir}$_prefix" \
+			libdir="${pkgdir}$_prefix/lib32" \
+			dlldir="${pkgdir}$_prefix/lib32/wine" install
 
 	# package wine 64-bit
 	msg2 'Packaging Wine-64...'
 	cd "${srcdir}/${pkgname}"-64-build
-	make 	prefix="${pkgdir}/usr" \
-			libdir="${pkgdir}/usr/lib" \
-			dlldir="${pkgdir}/usr/lib/wine" install
+	make 	prefix="${pkgdir}$_prefix" \
+			libdir="${pkgdir}$_prefix/lib" \
+			dlldir="${pkgdir}$_prefix/lib/wine" install
 
 	# freetype font smoothing for win32 applications
 	install -d "$pkgdir"/etc/fonts/conf.{avail,d}
-	install -m644 "${srcdir}/30-win32-aliases.conf" "${pkgdir}/etc/fonts/conf.avail"
-	ln -s ../conf.avail/30-win32-aliases.conf "${pkgdir}/etc/fonts/conf.d/30-win32-aliases.conf"
+	install -m644 "${srcdir}/30-win32-aliases.conf" "${pkgdir}/etc/fonts/conf.avail/30-$pkgname-win32-aliases.conf"
+	ln -s "../conf.avail/30-$pkgname-win32-aliases.conf" "${pkgdir}/etc/fonts/conf.d/30-$pkgname-win32-aliases.conf"
 
 	# wine binfmt
-	install -Dm 644 "${srcdir}/wine-binfmt.conf" "${pkgdir}/usr/lib/binfmt.d/wine.conf"
+	if [[ $_INSTALL_TO_OPT == true ]]; then
+	  mkdir -p "${pkgdir}/usr/lib/binfmt.d"
+	  # change binfmt.conf to actual installed path
+	  sed -e "s|/usr/bin/wine|$_prefix/bin/wine|g" < "${srcdir}/wine-binfmt.conf" > "${pkgdir}/usr/lib/binfmt.d/$pkgname.conf"
+	else
+	  install -Dm 644 "${srcdir}/wine-binfmt.conf" "${pkgdir}/usr/lib/binfmt.d/wine.conf"
+	fi
 
 	# dxvk
 	if [ $_use_dxvk == "true" ]; then
-	  cp -rv "${srcdir}"/"${_dxvksrcdir}"/build/dxvk-master/x32/* "${pkgdir}"/usr/lib32/wine
-	  cp -rv "${srcdir}"/"${_dxvksrcdir}"/build/dxvk-master/x64/* "${pkgdir}"/usr/lib/wine
+	  cp -rv "${srcdir}"/"${_dxvksrcdir}"/build/dxvk-master/x32/* "${pkgdir}$_prefix"/lib32/wine
+	  cp -rv "${srcdir}"/"${_dxvksrcdir}"/build/dxvk-master/x64/* "${pkgdir}$_prefix"/lib/wine
 	fi
 
 	rm -fv $_where/BIG_UGLY_COINMINER # state tracker end
@@ -727,6 +748,11 @@ package() {
 	  msg2 'https://raw.githubusercontent.com/zfigura/wine/esync/README.esync'
 	  msg2 ''
 	  msg2 '##########################################################################################################################'
+	fi
+
+	if [[ $_INSTALL_TO_OPT == "true" ]]; then
+	  msg2 "### This wine will be installed to: $_prefix"
+	  msg2 "### Remember to use $_prefix/bin/wine instead of just wine (same for winecfg etc.)"
 	fi
 }
 md5sums=('SKIP'

--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -67,6 +67,11 @@ if [[ $_use_dxvk == "true" ]]; then
   msg2 "Using DXVK winelib for d3d10 and d3d11 translation"
 fi
 
+if [[ $_lowlatency_audio == "true" ]]; then
+  pkgname="${pkgname/%-git/-osu-git}"
+  msg2 "Using low latency audio patch"
+fi
+
 # custom plain wine commit to pass to git
 if [ $_use_staging == "false" ] && [ -n "$_plain_version" ]; then
   _plain_commit="#commit=$_plain_version"

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -17,6 +17,10 @@ _NOCOMPILE="false"
 # Set to true if you want to skip the initial prompt
 _NOINITIALPROMPT="false"
 
+# Set to true to install into /opt/wine-something instead of /usr; this allows you to install multiple different versions in parallel
+# Don't forget that you'll have to use /opt/wine-something/bin/wine instead of just wine (same for winecfg etc.)
+_INSTALL_TO_OPT="false"
+
 
 #### WINE FLAVOUR SETTINGS ####
 #### Changing the configuration below will reset pkgrel to 1, that's normal and harmless

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -8,7 +8,7 @@ _COMPILEWITH="gcc"
 # Set to true to build optimized binaries. If you're planning to share the resulting package, set to false (as -march=native will be used)
 _OPTIMIZED="true"
 
-# Set to true to nuke source and package dirs as well as esync.tgz on a successful build so it's clean and ready for the next one
+# Set to true to nuke source and package dirs on a successful build so it's clean and ready for the next one
 _NUKR="true"
 
 # Set to true if you do not want to compile your build after its source is ready - For source sharing/debugging


### PR DESCRIPTION
This PR proposes the following changes to the `wine-tkg-git` PKGBUILD:

1. Move the patch choices from `pkgver` to `pkgname`. This makes it significantly easier to handle multiple different builds e.g. in a single local repository. This generates package names like `wine-tkg-staging-esync-pba-git`.
2. Also show the low latency patch in `pkgname` (as `-osu`), because the customization.cfg itself states "Using this patch for something else than Osu! isn't recommended".
3. Same for `$_OPTIMIZED`, because it may be relevant if handling multiple versions across different machines.
4. Allow to install into a subdirectory of `/opt`, instead of the default `/usr`. This allows to have multiple different versions installed at the same time.
   If this option is enabled, the conf file in binfmt.d will be renamed to `$pkgname.conf`, and thus will be overridden by a later-ordered `wine.conf` file if one exists, so that `/usr/bin/wine` will be preferred.
   This patch unconditionally renames the conf file in `/etc/fonts/conf.{avail,d}` to `30-$pkgname-win32-aliases.conf` to avoid file name collisions.
   This unfortunately means that we cannot provide `wine` and similar packages, as otherwise it would be impossible to have a different wine (e.g. from official repos) installed to `/usr`. (This does not apply if installing to `/usr`.)
5. I didn't like the hacky style the `ccache` check looked, so I made it more elegant.
6. Download the `esync.tgz` patchset into `esync$_esync_version.tgz`, so that it doesn't need to be nuked and redownloaded for every build.
7. Enforce installing a wine package via `makedepends` if building with DXVK was requested. This allows building in a clean chroot via Arch's automated scripts.