### PR TITLE
Add building with gcc7 (for bypass bug 45199)

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -360,6 +360,14 @@ prepare() {
 	    export COMMON_FLAGS="-std=gnu89 -g -march=native -pipe -O3"
 	    export LDFLAGS="-O3"
 	  fi
+	elif [ $_COMPILEWITH == 'gcc7' ]; then
+	  export CC="gcc-7"
+	  export CXX="g++-7"
+	  echo "Using gcc7 compiler" >> $_where/last_build_config.log
+	  if [ $_OPTIMIZED == 'true' ]; then
+	    export COMMON_FLAGS="-march=native -pipe -Os"
+	    export LDFLAGS="-Os"
+	  fi
 	else
 	  echo "Using gcc compiler" >> $_where/last_build_config.log
 	  if [ $_OPTIMIZED == 'true' ]; then

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -2,7 +2,7 @@
 
 #### COMPILER/BUILD OPTIONS ####
 
-# Compiler choice - Supports "gcc", "clang" and "zapcc" options
+# Compiler choice - Supports "gcc", "gcc7" (bug 45199), "clang" and "zapcc" options
 _COMPILEWITH="gcc"
 
 # Set to true to build optimized binaries. If you're planning to share the resulting package, set to false (as -march=native will be used)


### PR DESCRIPTION
Adding gcc7 for _COMPILEWITH option.
https://bugs.winehq.org/show_bug.cgi?id=45199