### PR TITLE
Add fullscreen hack from Valve's Proton WINE fork

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -1,8 +1,8 @@
 # Created by: Tk-Glitch <ti3nou at gmail dot com>
 
 pkgname=wine-tkg-git
-pkgver=3.20.r0.ga1b38470
-pkgrel=85
+pkgver=3.20.r1.g84f6fd6c
+pkgrel=86
 _winesrcdir='wine-git'
 _stgsrcdir='wine-staging-git'
 _pbasrcdir='wine-pba'
@@ -243,6 +243,7 @@ source=("$_winesrcdir"::"git://source.winehq.org/git/wine.git${_plain_commit}"
 		'dxvk-winelib.patch' # Enables DXVK winelib building
 		'FS_bypass_compositor.patch' # Perf
 		'faudio-exp.patch'
+		'valve_proton_fullscreen_hack-staging.patch'
 )
 
 if [[ $_INSTALL_TO_OPT != true ]]; then
@@ -637,6 +638,11 @@ prepare() {
 	  _withd3d9nine='--with-d3d9-nine'
 	fi
 
+	# Proton Fullscreen patch - Allows resolution changes for fullscreen games without changing desktop resolution
+	if [ $_proton_fs_hack == "true" ] && [ $_use_staging == "true" ]; then
+	  patch -Np1 < ../'valve_proton_fullscreen_hack-staging.patch' && echo "Applied Proton fullscreen hack patch" >> "$_where"/last_build_config.log
+	fi
+
 	# wine user patches
 	if [ $_user_patches == "true" ]; then
 	  _userpatch_target="plain-wine"
@@ -840,7 +846,8 @@ md5sums=('SKIP'
          '78ea7fa80abd8beb6e2afac27deb938f'
          'd328bfd0d363434fe5f83f3a614849f7'
          '5ca4ee142eafe2c8873d59b2feb51a7d'
-         'a14ecda90103c476b486c187beebf7ad')
+         'a14ecda90103c476b486c187beebf7ad'
+         'b712b61af7ecfe09ecfced5fc2a9ea13')
 
 function exit_cleanup {
   rm -fv "$_where"/BIG_UGLY_COINMINER # state tracker end

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -101,6 +101,8 @@ _clock_monotonic="true"
 # Bypass compositor in fullscreen mode - Reduces stuttering and improves performance - https://github.com/ValveSoftware/wine/commit/141ba5cf73029029a5a0bd2cdcfd5f9f9ab7ee7b
 _FS_bypass_compositor="true"
 
+# Proton Fullscreen patch - Requires staging - Allows resolution changes for fullscreen games without changing desktop resolution
+_proton_fs_hack="false"
 
 #### USER PATCHES ####
 

--- a/wine-tkg-git/wine-tkg-patches/valve_proton_fullscreen_hack-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/valve_proton_fullscreen_hack-staging.patch
@@ -1,0 +1,1473 @@
+diff --git a/dlls/winex11.drv/desktop.c b/dlls/winex11.drv/desktop.c
+index d478cbdcb3..6d2eb0673e 100644
+--- a/dlls/winex11.drv/desktop.c
++++ b/dlls/winex11.drv/desktop.c
+@@ -234,18 +234,51 @@ static BOOL CALLBACK update_windows_on_desktop_resize( HWND hwnd, LPARAM lparam
+ 
+     if (!(data = get_win_data( hwnd ))) return TRUE;
+ 
+-    /* update the full screen state */
+-    update_net_wm_states( data );
++    if (fs_hack_enabled() &&
++            fs_hack_matches_current_mode(
++                data->whole_rect.right - data->whole_rect.left,
++                data->whole_rect.bottom - data->whole_rect.top)){
++        if(!data->fs_hack){
++            POINT p = fs_hack_real_mode();
++            POINT tl = virtual_screen_to_root(0, 0);
++            TRACE("Enabling fs hack, resizing the window to (%u,%u)-(%u,%u)\n", tl.x, tl.y, p.x, p.y);
++            data->fs_hack = TRUE;
++            XMoveResizeWindow(data->display, data->whole_window, tl.x, tl.y, p.x, p.y);
++            if(data->client_window)
++                XMoveResizeWindow(data->display, data->client_window, 0, 0, p.x, p.y);
++            sync_gl_drawable(hwnd);
++            update_net_wm_states( data );
++        }
++    }else {
+ 
+-    if (resize_data->old_virtual_rect.left != resize_data->new_virtual_rect.left) mask |= CWX;
+-    if (resize_data->old_virtual_rect.top != resize_data->new_virtual_rect.top) mask |= CWY;
+-    if (mask && data->whole_window)
+-    {
+-        POINT pos = virtual_screen_to_root( data->whole_rect.left, data->whole_rect.top );
+-        XWindowChanges changes;
+-        changes.x = pos.x;
+-        changes.y = pos.y;
+-        XReconfigureWMWindow( data->display, data->whole_window, data->vis.screen, mask, &changes );
++        /* update the full screen state */
++        update_net_wm_states( data );
++
++        if (resize_data->old_virtual_rect.left != resize_data->new_virtual_rect.left || data->fs_hack) mask |= CWX;
++        if (resize_data->old_virtual_rect.top != resize_data->new_virtual_rect.top || data->fs_hack) mask |= CWY;
++        if (mask && data->whole_window)
++        {
++            POINT pos = virtual_screen_to_root( data->whole_rect.left, data->whole_rect.top );
++            XWindowChanges changes;
++            changes.x = pos.x;
++            changes.y = pos.y;
++            XReconfigureWMWindow( data->display, data->whole_window, data->vis.screen, mask, &changes );
++        }
++
++        if(data->fs_hack &&
++            !fs_hack_matches_current_mode(
++                data->whole_rect.right - data->whole_rect.left,
++                data->whole_rect.bottom - data->whole_rect.top)){
++            TRACE("Disabling fs hack\n");
++            data->fs_hack = FALSE;
++            if(data->client_window){
++                XMoveResizeWindow(data->display, data->client_window,
++                        data->client_rect.left, data->client_rect.top,
++                        data->client_rect.right - data->client_rect.left,
++                        data->client_rect.bottom - data->client_rect.top);
++            }
++            sync_gl_drawable(hwnd);
++        }
+     }
+     release_win_data( data );
+     if (hwnd == GetForegroundWindow()) clip_fullscreen_window( hwnd, TRUE );
+diff --git a/dlls/winex11.drv/event.c b/dlls/winex11.drv/event.c
+index b8207aad48..6d129574ab 100644
+--- a/dlls/winex11.drv/event.c
++++ b/dlls/winex11.drv/event.c
+@@ -806,9 +806,27 @@ static void focus_out( Display *display , HWND hwnd )
+     Window focus_win;
+     int revert;
+     XIC xic;
++    struct x11drv_win_data *data;
+ 
+     if (ximInComposeMode) return;
+ 
++    data = get_win_data(hwnd);
++    if(data){
++        ULONGLONG now = GetTickCount64();
++        if(data->take_focus_back > 0 &&
++                now >= data->take_focus_back &&
++                now - data->take_focus_back < 100){
++            data->take_focus_back = 0;
++            TRACE("workaround mutter bug, taking focus back\n");
++            XSetInputFocus( data->display, data->whole_window, RevertToParent, CurrentTime);
++            release_win_data(data);
++            /* don't inform win32 client */
++            return;
++        }
++        data->take_focus_back = 0;
++        release_win_data(data);
++    }
++
+     x11drv_thread_data()->last_focus = hwnd;
+     if ((xic = X11DRV_get_ic( hwnd ))) XUnsetICFocus( xic );
+ 
+@@ -1112,8 +1130,16 @@ static BOOL X11DRV_ConfigureNotify( HWND hwnd, XEvent *xev )
+     }
+     else pos = root_to_virtual_screen( x, y );
+ 
+-    X11DRV_X_to_window_rect( data, &rect, pos.x, pos.y, event->width, event->height );
+-    if (root_coords) MapWindowPoints( 0, parent, (POINT *)&rect, 2 );
++    if(data->fs_hack){
++        POINT p = fs_hack_current_mode();
++        rect.left = 0;
++        rect.top = 0;
++        rect.right = p.x;
++        rect.bottom = p.y;
++    }else{
++        X11DRV_X_to_window_rect( data, &rect, pos.x, pos.y, event->width, event->height );
++        if (root_coords) MapWindowPoints( 0, parent, (POINT *)&rect, 2 );
++    }
+ 
+     TRACE( "win %p/%lx new X rect %d,%d,%dx%d (event %d,%d,%dx%d)\n",
+            hwnd, data->whole_window, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top,
+@@ -1477,6 +1503,7 @@ static void EVENT_DropFromOffiX( HWND hWnd, XClientMessageEvent *event )
+     Window		win, w_aux_root, w_aux_child;
+ 
+     if (!(data = get_win_data( hWnd ))) return;
++    ERR("TODO: fs hack\n");
+     cx = data->whole_rect.right - data->whole_rect.left;
+     cy = data->whole_rect.bottom - data->whole_rect.top;
+     win = data->whole_window;
+diff --git a/dlls/winex11.drv/mouse.c b/dlls/winex11.drv/mouse.c
+index 1209a250b0..d23c956af3 100644
+--- a/dlls/winex11.drv/mouse.c
++++ b/dlls/winex11.drv/mouse.c
+@@ -385,6 +385,7 @@ static BOOL grab_clipping_window( const RECT *clip )
+     Window clip_window;
+     HWND msg_hwnd = 0;
+     POINT pos;
++    RECT real_clip;
+ 
+     if (GetWindowThreadProcessId( GetDesktopWindow(), NULL ) == GetCurrentThreadId())
+         return TRUE;  /* don't clip in the desktop process */
+@@ -410,9 +411,28 @@ static BOOL grab_clipping_window( const RECT *clip )
+     TRACE( "clipping to %s win %lx\n", wine_dbgstr_rect(clip), clip_window );
+ 
+     if (!data->clip_hwnd) XUnmapWindow( data->display, clip_window );
+-    pos = virtual_screen_to_root( clip->left, clip->top );
++
++    pos.x = clip->left;
++    pos.y = clip->top;
++    fs_hack_user_to_real(&pos);
++    real_clip.left = pos.x;
++    real_clip.top = pos.y;
++
++    pos.x = clip->right;
++    pos.y = clip->bottom;
++    fs_hack_user_to_real(&pos);
++    real_clip.right = pos.x;
++    real_clip.bottom = pos.y;
++
++    pos = virtual_screen_to_root( real_clip.left, real_clip.top );
++
++    TRACE("setting real clip to %d,%d x %d,%d\n",
++            pos.x, pos.y,
++            real_clip.right - real_clip.left,
++            real_clip.bottom - real_clip.top);
++
+     XMoveResizeWindow( data->display, clip_window, pos.x, pos.y,
+-                       max( 1, clip->right - clip->left ), max( 1, clip->bottom - clip->top ) );
++                       max( 1, real_clip.right - real_clip.left ), max( 1, real_clip.bottom - real_clip.top ) );
+     XMapWindow( data->display, clip_window );
+ 
+     /* if the rectangle is shrinking we may get a pointer warp */
+@@ -432,6 +452,7 @@ static BOOL grab_clipping_window( const RECT *clip )
+         return FALSE;
+     }
+     clip_rect = *clip;
++    TRACE("new clip rect: %s\n", wine_dbgstr_rect(&clip_rect));
+     if (!data->clip_hwnd) sync_window_cursor( clip_window );
+     InterlockedExchangePointer( (void **)&cursor_window, msg_hwnd );
+     data->clip_hwnd = msg_hwnd;
+@@ -583,8 +604,18 @@ static void send_mouse_input( HWND hwnd, Window window, unsigned int state, INPU
+             sync_window_cursor( window );
+             last_cursor_change = input->u.mi.time;
+         }
+-        input->u.mi.dx += clip_rect.left;
+-        input->u.mi.dy += clip_rect.top;
++
++        pt.x = clip_rect.left;
++        pt.y = clip_rect.top;
++        fs_hack_user_to_real(&pt);
++
++        pt.x += input->u.mi.dx;
++        pt.y += input->u.mi.dy;
++        fs_hack_real_to_user(&pt);
++
++        input->u.mi.dx = pt.x;
++        input->u.mi.dy = pt.y;
++
+         __wine_send_input( hwnd, input );
+         return;
+     }
+@@ -598,7 +629,13 @@ static void send_mouse_input( HWND hwnd, Window window, unsigned int state, INPU
+ 
+     if (!(data = get_win_data( hwnd ))) return;
+ 
+-    if (window == data->whole_window)
++    if(data->fs_hack)
++        fs_hack_real_to_user(&pt);
++
++    input->u.mi.dx = pt.x;
++    input->u.mi.dy = pt.y;
++
++    if (window == data->whole_window && !data->fs_hack)
+     {
+         pt.x += data->whole_rect.left - data->client_rect.left;
+         pt.y += data->whole_rect.top - data->client_rect.top;
+@@ -1432,13 +1469,19 @@ void CDECL X11DRV_SetCursor( HCURSOR handle )
+ BOOL CDECL X11DRV_SetCursorPos( INT x, INT y )
+ {
+     struct x11drv_thread_data *data = x11drv_init_thread_data();
+-    POINT pos = virtual_screen_to_root( x, y );
++    POINT pos = {x, y};
++
++    fs_hack_user_to_real(&pos);
++    pos = virtual_screen_to_root( pos.x, pos.y );
++
++    TRACE("real setting to %u, %u\n",
++            pos.x, pos.y);
+ 
+     XWarpPointer( data->display, root_window, root_window, 0, 0, 0, 0, pos.x, pos.y );
+     data->warp_serial = NextRequest( data->display );
+     XNoOp( data->display );
+     XFlush( data->display ); /* avoids bad mouse lag in games that do their own mouse warping */
+-    TRACE( "warped to %d,%d serial %lu\n", x, y, data->warp_serial );
++    TRACE( "warped to (fake) %d,%d serial %lu\n", x, y, data->warp_serial );
+     return TRUE;
+ }
+ 
+@@ -1457,7 +1500,8 @@ BOOL CDECL X11DRV_GetCursorPos(LPPOINT pos)
+     if (ret)
+     {
+         POINT old = *pos;
+-        *pos = root_to_virtual_screen( winX, winY );
++        POINT p = root_to_virtual_screen( winX, winY );
++        fs_hack_real_to_user(&p);
+         TRACE( "pointer at %s server pos %s\n", wine_dbgstr_point(pos), wine_dbgstr_point(&old) );
+     }
+     return ret;
+@@ -1487,8 +1531,9 @@ BOOL CDECL X11DRV_ClipCursor( LPCRECT clip )
+         }
+ 
+         /* we are clipping if the clip rectangle is smaller than the screen */
+-        if (clip->left > virtual_rect.left || clip->right < virtual_rect.right ||
+-            clip->top > virtual_rect.top || clip->bottom < virtual_rect.bottom)
++        if (!(!fs_hack_enabled() && clip->left == 0 && clip->top == 0 && fs_hack_matches_last_mode(clip->right, clip->bottom)) && /* fix games trying to reset clip to full screen */
++                (clip->left > virtual_rect.left || clip->right < virtual_rect.right ||
++                 clip->top > virtual_rect.top || clip->bottom < virtual_rect.bottom))
+         {
+             if (grab_clipping_window( clip )) return TRUE;
+         }
+@@ -1730,6 +1775,7 @@ static BOOL X11DRV_RawMotion( XGenericEventCookie *xev )
+     const double *values = event->valuators.values;
+     RECT virtual_rect;
+     INPUT input;
++    POINT pt;
+     int i;
+     double dx = 0, dy = 0, val;
+     struct x11drv_thread_data *thread_data = x11drv_thread_data();
+@@ -1813,6 +1859,12 @@ static BOOL X11DRV_RawMotion( XGenericEventCookie *xev )
+         return FALSE;
+     }
+ 
++    pt.x = input.u.mi.dx;
++    pt.y = input.u.mi.dy;
++    fs_hack_scale_real_to_user(&pt);
++    input.u.mi.dx = pt.x;
++    input.u.mi.dy = pt.y;
++
+     TRACE( "pos %d,%d (event %f,%f, accum %f,%f)\n", input.u.mi.dx, input.u.mi.dy, dx, dy, x_rel->accum, y_rel->accum );
+ 
+     input.type = INPUT_MOUSE;
+diff --git a/dlls/winex11.drv/opengl.c b/dlls/winex11.drv/opengl.c
+index 9de3ded4af..10e39dd43f 100644
+--- a/dlls/winex11.drv/opengl.c
++++ b/dlls/winex11.drv/opengl.c
+@@ -43,6 +43,10 @@
+ #include "wine/library.h"
+ #include "wine/debug.h"
+ 
++#ifndef ARRAY_SIZE
++#define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
++#endif
++
+ #ifdef SONAME_LIBGL
+ 
+ WINE_DEFAULT_DEBUG_CHANNEL(wgl);
+@@ -205,6 +209,12 @@ struct wgl_context
+     struct gl_drawable *drawables[2];
+     struct gl_drawable *new_drawables[2];
+     BOOL refresh_drawables;
++    BOOL fs_hack;
++    GLuint fs_hack_fbo, fs_hack_resolve_fbo;
++    GLuint fs_hack_color_texture, fs_hack_ds_texture;
++    GLuint fs_hack_color_renderbuffer, fs_hack_color_resolve_renderbuffer, fs_hack_ds_renderbuffer;
++    POINT setup_for;
++    GLuint current_draw_fbo, current_read_fbo;
+     struct list entry;
+ };
+ 
+@@ -248,6 +258,10 @@ struct gl_drawable
+     SIZE                           pixmap_size;  /* pixmap size for GLXPixmap drawables */
+     int                            swap_interval;
+     BOOL                           refresh_swap_interval;
++    BOOL                           fs_hack;
++    BOOL                           fs_hack_did_swapbuf;
++    BOOL                           fs_hack_context_set_up;
++    BOOL                           has_scissor_indexed;
+ };
+ 
+ enum glx_swap_control_method
+@@ -372,6 +386,10 @@ static int   (*pglXSwapIntervalSGI)(int);
+ static void* (*pglXAllocateMemoryNV)(GLsizei size, GLfloat readfreq, GLfloat writefreq, GLfloat priority);
+ static void  (*pglXFreeMemoryNV)(GLvoid *pointer);
+ 
++static void (*pglScissorIndexed)(GLuint, GLint, GLint, GLsizei, GLsizei);
++static void (*pglScissorIndexedv)(GLuint, const GLint *);
++static void (*pglGetIntegeri_v)(GLenum, GLuint, GLint *);
++
+ /* MESA GLX Extensions */
+ static void (*pglXCopySubBufferMESA)(Display *dpy, GLXDrawable drawable, int x, int y, int width, int height);
+ static int (*pglXSwapIntervalMESA)(unsigned int interval);
+@@ -395,6 +413,27 @@ static void wglFinish(void);
+ static void wglFlush(void);
+ static const GLubyte *wglGetString(GLenum name);
+ 
++/* Fullscreen hack */
++static void (*pglBindFramebuffer)( GLenum target, GLuint framebuffer );
++static void (*pglBindFramebufferEXT)( GLenum target, GLuint framebuffer );
++static void (*pglBindRenderbuffer)( GLenum target, GLuint renderbuffer );
++static void (*pglBlitFramebuffer)( GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter );
++void (*pglDeleteFramebuffers)( GLsizei n, const GLuint *framebuffers );
++void (*pglDeleteRenderbuffers)( GLsizei n, const GLuint *renderbuffers );
++static void (*pglDrawBuffer)( GLenum buffer );
++static void (*pglFramebufferRenderbuffer)( GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer );
++static void (*pglFramebufferTexture2D)( GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level );
++static void (*pglGenFramebuffers)( GLsizei n, GLuint *ids );
++static void (*pglGenRenderbuffers)( GLsizei n, GLuint *renderbuffers );
++static void (*pglReadBuffer)( GLenum src );
++static void (*pglRenderbufferStorage)( GLenum target, GLenum internalformat, GLsizei width, GLsizei height );
++static void (*pglRenderbufferStorageMultisample)( GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height );
++
++static void wglBindFramebuffer( GLenum target, GLuint framebuffer );
++static void wglBindFramebufferEXT( GLenum target, GLuint framebuffer );
++static void wglDrawBuffer( GLenum buffer );
++static void wglReadBuffer( GLenum src );
++
+ /* check if the extension is present in the list */
+ static BOOL has_extension( const char *list, const char *ext )
+ {
+@@ -570,9 +609,11 @@ static BOOL WINAPI init_opengl( INIT_ONCE *once, void *param, void **context )
+     /* redirect some standard OpenGL functions */
+ #define REDIRECT(func) \
+     do { p##func = opengl_funcs.gl.p_##func; opengl_funcs.gl.p_##func = w##func; } while(0)
++    REDIRECT( glDrawBuffer );
+     REDIRECT( glFinish );
+     REDIRECT( glFlush );
+     REDIRECT( glGetString );
++    REDIRECT( glReadBuffer );
+ #undef REDIRECT
+ 
+     pglXGetProcAddressARB = wine_dlsym(opengl_handle, "glXGetProcAddressARB", NULL, 0);
+@@ -581,6 +622,22 @@ static BOOL WINAPI init_opengl( INIT_ONCE *once, void *param, void **context )
+         goto failed;
+     }
+ 
++    /* Fullscreen hack */
++#define LOAD_FUNCPTR(func) p##func = (void *)pglXGetProcAddressARB((const unsigned char *)#func);
++    LOAD_FUNCPTR( glBindFramebuffer );
++    LOAD_FUNCPTR( glBindFramebufferEXT );
++    LOAD_FUNCPTR( glBindRenderbuffer );
++    LOAD_FUNCPTR( glBlitFramebuffer );
++    LOAD_FUNCPTR( glDeleteFramebuffers );
++    LOAD_FUNCPTR( glDeleteRenderbuffers );
++    LOAD_FUNCPTR( glFramebufferRenderbuffer );
++    LOAD_FUNCPTR( glFramebufferTexture2D );
++    LOAD_FUNCPTR( glGenFramebuffers );
++    LOAD_FUNCPTR( glGenRenderbuffers );
++    LOAD_FUNCPTR( glRenderbufferStorage );
++    LOAD_FUNCPTR( glRenderbufferStorageMultisample );
++#undef LOAD_FUNCPTR
++
+ #define LOAD_FUNCPTR(f) do if((p##f = (void*)pglXGetProcAddressARB((const unsigned char*)#f)) == NULL) \
+     { \
+         ERR( "%s not found in libGL, disabling OpenGL.\n", #f ); \
+@@ -632,6 +689,10 @@ static BOOL WINAPI init_opengl( INIT_ONCE *once, void *param, void **context )
+     /* NV GLX Extension */
+     LOAD_FUNCPTR(glXAllocateMemoryNV);
+     LOAD_FUNCPTR(glXFreeMemoryNV);
++
++    LOAD_FUNCPTR(glScissorIndexed);
++    LOAD_FUNCPTR(glScissorIndexedv);
++    LOAD_FUNCPTR(glGetIntegeri_v);
+ #undef LOAD_FUNCPTR
+ 
+     if(!X11DRV_WineGL_InitOpenglInfo()) goto failed;
+@@ -721,6 +782,13 @@ static BOOL WINAPI init_opengl( INIT_ONCE *once, void *param, void **context )
+         pglXSwapBuffersMscOML = pglXGetProcAddressARB( (const GLubyte *)"glXSwapBuffersMscOML" );
+     }
+ 
++    if (has_extension( glExtensions, "GL_ARB_viewport_array"))
++    {
++        opengl_funcs.ext.p_glGetIntegeri_v = pglGetIntegeri_v;
++        opengl_funcs.ext.p_glScissorIndexed = pglScissorIndexed;
++        opengl_funcs.ext.p_glScissorIndexedv = pglScissorIndexedv;
++    }
++
+     X11DRV_WineGL_LoadExtensions();
+     init_pixel_formats( gdi_display );
+     return TRUE;
+@@ -1354,10 +1422,17 @@ static struct gl_drawable *create_gl_drawable( HWND hwnd, const struct wgl_pixel
+ 
+     if (GetAncestor( hwnd, GA_PARENT ) == GetDesktopWindow())  /* top-level window */
+     {
++        struct x11drv_win_data *data;
++
+         gl->type = DC_GL_WINDOW;
+         gl->window = create_client_window( hwnd, visual );
+         if (gl->window)
+             gl->drawable = pglXCreateWindow( gdi_display, gl->format->fbconfig, gl->window, NULL );
++        data = get_win_data( hwnd );
++        gl->fs_hack = data->fs_hack;
++        if (gl->fs_hack)
++            TRACE( "Window %p has the fullscreen hack enabled\n", hwnd );
++        release_win_data( data );
+         TRACE( "%p created client %lx drawable %lx\n", hwnd, gl->window, gl->drawable );
+     }
+ #ifdef SONAME_LIBXCOMPOSITE
+@@ -1480,6 +1555,9 @@ static BOOL set_pixel_format(HDC hdc, int format, BOOL allow_change)
+ void sync_gl_drawable( HWND hwnd )
+ {
+     struct gl_drawable *old, *new;
++    struct x11drv_win_data *data;
++
++    TRACE("%p\n", hwnd);
+ 
+     if (!(old = get_gl_drawable( hwnd, 0 ))) return;
+ 
+@@ -1493,6 +1571,11 @@ void sync_gl_drawable( HWND hwnd )
+         release_gl_drawable( new );
+         break;
+     default:
++        data = get_win_data( hwnd );
++        old->fs_hack = data->fs_hack;
++        if (old->fs_hack)
++            TRACE( "Window %p has the fullscreen hack enabled\n", hwnd );
++        release_win_data( data );
+         break;
+     }
+     release_gl_drawable( old );
+@@ -1791,6 +1874,10 @@ static BOOL glxdrv_wglDeleteContext(struct wgl_context *ctx)
+ static PROC glxdrv_wglGetProcAddress(LPCSTR lpszProc)
+ {
+     if (!strncmp(lpszProc, "wgl", 3)) return NULL;
++    if (!strcmp(lpszProc, "glBindFramebuffer"))
++        return (PROC)wglBindFramebuffer;
++    if (!strcmp(lpszProc, "glBindFramebufferEXT"))
++        return (PROC)wglBindFramebufferEXT;
+     return pglXGetProcAddressARB((const GLubyte*)lpszProc);
+ }
+ 
+@@ -1810,12 +1897,234 @@ static void set_context_drawables( struct wgl_context *ctx, struct gl_drawable *
+     for (i = 0; i < 4; i++) release_gl_drawable( prev[i] );
+ }
+ 
++struct fs_hack_fbconfig_attribs
++{
++    int render_type;
++    int buffer_size;
++    int red_size;
++    int green_size;
++    int blue_size;
++    int alpha_size;
++    int depth_size;
++    int stencil_size;
++    int doublebuffer;
++    int samples;
++    int srgb;
++};
++
++struct fs_hack_fbo_attachments_config
++{
++    GLint color_internalformat;
++    GLenum color_format;
++    GLenum color_type;
++    GLint ds_internalformat;
++    GLenum ds_format;
++    GLenum ds_type;
++    int samples;
++};
++
++static void fs_hack_get_attachments_config( struct gl_drawable *gl, struct fs_hack_fbconfig_attribs *attribs,
++        struct fs_hack_fbo_attachments_config *config )
++{
++    if (attribs->render_type != GLX_RGBA_BIT)
++        FIXME( "Unsupported GLX_RENDER_TYPE %#x.\n", attribs->render_type );
++    if (attribs->red_size != 8 || attribs->green_size != 8 || attribs->blue_size != 8)
++        FIXME( "Unsupported RGBA color sizes {%u, %u, %u, %u}.\n",
++                attribs->red_size, attribs->green_size, attribs->blue_size, attribs->alpha_size );
++    if (attribs->srgb)
++        config->color_internalformat = attribs->alpha_size ? GL_SRGB8_ALPHA8 : GL_SRGB8;
++    else
++        config->color_internalformat = attribs->alpha_size ? GL_RGBA8 : GL_RGB8;
++    config->color_format = GL_BGRA;
++    config->color_type = GL_UNSIGNED_INT_8_8_8_8_REV;
++    if (attribs->depth_size || attribs->stencil_size)
++    {
++        if (attribs->depth_size != 24)
++            FIXME( "Unsupported depth buffer size %u.\n", attribs->depth_size );
++        if (attribs->stencil_size && attribs->stencil_size != 8)
++            FIXME( "Unsupported stencil buffer size %u.\n", attribs->stencil_size );
++        config->ds_internalformat = attribs->stencil_size ? GL_DEPTH24_STENCIL8 : GL_DEPTH_COMPONENT24;
++        config->ds_format = attribs->stencil_size ? GL_DEPTH_STENCIL : GL_DEPTH_COMPONENT;
++        config->ds_type = attribs->stencil_size ? GL_UNSIGNED_INT_24_8 : GL_UNSIGNED_INT;
++    }
++    else
++    {
++        config->ds_internalformat = config->ds_format = config->ds_type = 0;
++    }
++    config->samples = attribs->samples;
++}
++
++static void fs_hack_setup_context( struct wgl_context *ctx, struct gl_drawable *gl )
++{
++    GLuint prev_draw_fbo, prev_read_fbo, prev_texture, prev_renderbuffer;
++    POINT p = fs_hack_current_mode();
++    float prev_clear_color[4];
++    unsigned int i;
++    struct fs_hack_fbo_attachments_config config;
++    struct fs_hack_fbconfig_attribs attribs;
++    static const struct fbconfig_attribs_query
++    {
++        int attribute;
++        unsigned int offset;
++    }
++    queries[] =
++    {
++        {GLX_RENDER_TYPE, offsetof(struct fs_hack_fbconfig_attribs, render_type)},
++        {GLX_BUFFER_SIZE, offsetof(struct fs_hack_fbconfig_attribs, buffer_size)},
++        {GLX_RED_SIZE, offsetof(struct fs_hack_fbconfig_attribs, red_size)},
++        {GLX_GREEN_SIZE, offsetof(struct fs_hack_fbconfig_attribs, green_size)},
++        {GLX_BLUE_SIZE, offsetof(struct fs_hack_fbconfig_attribs, blue_size)},
++        {GLX_ALPHA_SIZE, offsetof(struct fs_hack_fbconfig_attribs, alpha_size)},
++        {GLX_DEPTH_SIZE, offsetof(struct fs_hack_fbconfig_attribs, depth_size)},
++        {GLX_STENCIL_SIZE, offsetof(struct fs_hack_fbconfig_attribs, stencil_size)},
++        {GLX_DOUBLEBUFFER, offsetof(struct fs_hack_fbconfig_attribs, doublebuffer)},
++        {GLX_SAMPLES_ARB, offsetof(struct fs_hack_fbconfig_attribs, samples)},
++        {GLX_FRAMEBUFFER_SRGB_CAPABLE_EXT, offsetof(struct fs_hack_fbconfig_attribs, srgb)},
++    };
++    BYTE *ptr = (BYTE *)&attribs;
++
++    if (ctx->fs_hack)
++    {
++        opengl_funcs.gl.p_glGetIntegerv( GL_DRAW_FRAMEBUFFER_BINDING, (GLint *)&prev_draw_fbo );
++        opengl_funcs.gl.p_glGetIntegerv( GL_READ_FRAMEBUFFER_BINDING, (GLint *)&prev_read_fbo );
++        opengl_funcs.gl.p_glGetIntegerv( GL_TEXTURE_BINDING_2D, (GLint *)&prev_texture );
++        opengl_funcs.gl.p_glGetIntegerv( GL_RENDERBUFFER_BINDING, (GLint *)&prev_renderbuffer );
++        opengl_funcs.gl.p_glGetFloatv( GL_COLOR_CLEAR_VALUE, prev_clear_color );
++        TRACE( "Previous draw FBO %u, read FBO %u for ctx %p\n", prev_draw_fbo, prev_read_fbo, ctx);
++
++        if (!ctx->fs_hack_fbo)
++        {
++            pglGenFramebuffers( 1, &ctx->fs_hack_fbo );
++            pglGenFramebuffers( 1, &ctx->fs_hack_resolve_fbo );
++            TRACE( "Created FBO %u for fullscreen hack.\n", ctx->fs_hack_fbo );
++        }
++        pglBindFramebuffer( GL_DRAW_FRAMEBUFFER, ctx->fs_hack_fbo );
++
++        for (i = 0; i < ARRAY_SIZE(queries); ++i)
++            pglXGetFBConfigAttrib( gdi_display, gl->format->fbconfig, queries[i].attribute,
++                    (int *)&ptr[queries[i].offset] );
++        fs_hack_get_attachments_config( gl, &attribs, &config );
++
++        if (config.samples)
++        {
++            if (!ctx->fs_hack_color_renderbuffer)
++                pglGenRenderbuffers( 1, &ctx->fs_hack_color_renderbuffer );
++            pglBindRenderbuffer( GL_RENDERBUFFER, ctx->fs_hack_color_renderbuffer );
++            pglRenderbufferStorageMultisample( GL_RENDERBUFFER, config.samples,
++                    config.color_internalformat, p.x, p.y );
++            pglFramebufferRenderbuffer( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
++                    GL_RENDERBUFFER, ctx->fs_hack_color_renderbuffer );
++            TRACE( "Created renderbuffer %u for fullscreen hack.\n", ctx->fs_hack_color_renderbuffer );
++            pglGenRenderbuffers( 1, &ctx->fs_hack_color_resolve_renderbuffer );
++            pglBindRenderbuffer( GL_RENDERBUFFER, ctx->fs_hack_color_resolve_renderbuffer );
++            pglRenderbufferStorage( GL_RENDERBUFFER, config.color_internalformat, p.x, p.y );
++            pglBindFramebuffer( GL_DRAW_FRAMEBUFFER, ctx->fs_hack_resolve_fbo );
++            pglFramebufferRenderbuffer( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
++                    GL_RENDERBUFFER, ctx->fs_hack_color_resolve_renderbuffer );
++            pglBindFramebuffer( GL_DRAW_FRAMEBUFFER, ctx->fs_hack_fbo );
++            pglBindRenderbuffer( GL_RENDERBUFFER, prev_renderbuffer );
++            TRACE( "Also created renderbuffer %u and FBO %u for color resolve.\n",
++                    ctx->fs_hack_color_resolve_renderbuffer, ctx->fs_hack_resolve_fbo );
++        }
++        else
++        {
++            if (!ctx->fs_hack_color_texture)
++                opengl_funcs.gl.p_glGenTextures( 1, &ctx->fs_hack_color_texture );
++            opengl_funcs.gl.p_glBindTexture( GL_TEXTURE_2D, ctx->fs_hack_color_texture );
++            opengl_funcs.gl.p_glTexImage2D( GL_TEXTURE_2D, 0, config.color_internalformat, p.x, p.y,
++                    0, config.color_format, config.color_type, NULL);
++            opengl_funcs.gl.p_glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
++            opengl_funcs.gl.p_glBindTexture( GL_TEXTURE_2D, prev_texture );
++            pglFramebufferTexture2D( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
++                    GL_TEXTURE_2D, ctx->fs_hack_color_texture, 0 );
++            TRACE( "Created texture %u for fullscreen hack.\n", ctx->fs_hack_color_texture );
++        }
++
++        if (config.ds_internalformat)
++        {
++            if (config.samples)
++            {
++                if (!ctx->fs_hack_ds_renderbuffer)
++                    pglGenRenderbuffers( 1, &ctx->fs_hack_ds_renderbuffer );
++                pglBindRenderbuffer( GL_RENDERBUFFER, ctx->fs_hack_ds_renderbuffer );
++                pglRenderbufferStorageMultisample( GL_RENDERBUFFER, config.samples,
++                        config.ds_internalformat, p.x, p.y );
++                pglBindRenderbuffer( GL_RENDERBUFFER, prev_renderbuffer );
++                if (attribs.depth_size)
++                    pglFramebufferRenderbuffer( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
++                            GL_RENDERBUFFER, ctx->fs_hack_ds_renderbuffer );
++                if (attribs.stencil_size)
++                    pglFramebufferRenderbuffer( GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
++                            GL_RENDERBUFFER, ctx->fs_hack_ds_renderbuffer );
++                TRACE( "Created DS renderbuffer %u for fullscreen hack.\n", ctx->fs_hack_ds_renderbuffer );
++            }
++            else
++            {
++                if (!ctx->fs_hack_ds_texture)
++                    opengl_funcs.gl.p_glGenTextures( 1, &ctx->fs_hack_ds_texture );
++                opengl_funcs.gl.p_glBindTexture( GL_TEXTURE_2D, ctx->fs_hack_ds_texture );
++                opengl_funcs.gl.p_glTexImage2D( GL_TEXTURE_2D, 0, config.ds_internalformat, p.x, p.y,
++                        0, config.ds_format, config.ds_type, NULL);
++                opengl_funcs.gl.p_glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
++                opengl_funcs.gl.p_glBindTexture( GL_TEXTURE_2D, prev_texture );
++                if (attribs.depth_size)
++                    pglFramebufferTexture2D( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, ctx->fs_hack_ds_texture, 0 );
++                if (attribs.stencil_size)
++                    pglFramebufferTexture2D( GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, ctx->fs_hack_ds_texture, 0 );
++                TRACE( "Created DS texture %u for fullscreen hack.\n", ctx->fs_hack_ds_texture );
++            }
++        }
++
++        opengl_funcs.gl.p_glClearColor( 0.0f, 0.0f, 0.0f, 1.0f );
++        if(!gl->fs_hack_context_set_up)
++            opengl_funcs.gl.p_glClear( GL_COLOR_BUFFER_BIT );
++        pglBindFramebuffer( GL_DRAW_FRAMEBUFFER, 0 );
++        pglDrawBuffer( GL_BACK );
++        if(!gl->fs_hack_context_set_up)
++            opengl_funcs.gl.p_glClear( GL_COLOR_BUFFER_BIT );
++        opengl_funcs.gl.p_glClearColor( prev_clear_color[0], prev_clear_color[1], prev_clear_color[2], prev_clear_color[3] );
++        wglBindFramebuffer( GL_DRAW_FRAMEBUFFER, prev_draw_fbo );
++        wglBindFramebuffer( GL_READ_FRAMEBUFFER, prev_read_fbo );
++
++        ctx->setup_for = p;
++        gl->has_scissor_indexed = has_extension(glExtensions, "GL_ARB_viewport_array");
++        gl->fs_hack_context_set_up = TRUE;
++    }
++    else
++    {
++        TRACE( "Releasing fullscreen hack texture %u and FBO %u\n", ctx->fs_hack_color_texture, ctx->fs_hack_fbo );
++        if (ctx->current_draw_fbo == ctx->fs_hack_fbo)
++        {
++            pglBindFramebuffer( GL_DRAW_FRAMEBUFFER, 0 );
++            ctx->current_draw_fbo = 0;
++        }
++        if (ctx->current_read_fbo == ctx->fs_hack_fbo)
++        {
++            pglBindFramebuffer( GL_READ_FRAMEBUFFER, 0 );
++            ctx->current_read_fbo = 0;
++        }
++
++        pglDeleteRenderbuffers( 1, &ctx->fs_hack_ds_renderbuffer );
++        pglDeleteRenderbuffers( 1, &ctx->fs_hack_color_resolve_renderbuffer );
++        pglDeleteRenderbuffers( 1, &ctx->fs_hack_color_renderbuffer );
++        opengl_funcs.gl.p_glDeleteTextures( 1, &ctx->fs_hack_ds_texture );
++        opengl_funcs.gl.p_glDeleteTextures( 1, &ctx->fs_hack_color_texture );
++        ctx->fs_hack_color_renderbuffer = ctx->fs_hack_color_resolve_renderbuffer = ctx->fs_hack_ds_renderbuffer = 0;
++        ctx->fs_hack_color_texture = ctx->fs_hack_ds_texture = 0;
++        pglDeleteFramebuffers( 1, &ctx->fs_hack_resolve_fbo );
++        pglDeleteFramebuffers( 1, &ctx->fs_hack_fbo );
++        ctx->fs_hack_fbo = 0;
++
++        gl->fs_hack_context_set_up = FALSE;
++    }
++}
++
+ /***********************************************************************
+  *		glxdrv_wglMakeCurrent
+  */
+ static BOOL glxdrv_wglMakeCurrent(HDC hdc, struct wgl_context *ctx)
+ {
+-    BOOL ret = FALSE;
++    BOOL ret = FALSE, setup_fs_hack = FALSE;
+     struct gl_drawable *gl;
+ 
+     TRACE("(%p,%p)\n", hdc, ctx);
+@@ -1844,10 +2153,17 @@ static BOOL glxdrv_wglMakeCurrent(HDC hdc, struct wgl_context *ctx)
+         if (ret)
+         {
+             NtCurrentTeb()->glContext = ctx;
+-            ctx->has_been_current = TRUE;
++            if (ctx->fs_hack != gl->fs_hack || (ctx->fs_hack && ctx->drawables[0] != gl))
++                setup_fs_hack = TRUE;
+             ctx->hdc = hdc;
+             set_context_drawables( ctx, gl, gl );
+             ctx->refresh_drawables = FALSE;
++            if (setup_fs_hack)
++            {
++                ctx->fs_hack = gl->fs_hack;
++                fs_hack_setup_context( ctx, gl );
++            }
++            ctx->has_been_current = TRUE;
+             LeaveCriticalSection( &context_section );
+             goto done;
+         }
+@@ -1866,7 +2182,7 @@ done:
+  */
+ static BOOL X11DRV_wglMakeContextCurrentARB( HDC draw_hdc, HDC read_hdc, struct wgl_context *ctx )
+ {
+-    BOOL ret = FALSE;
++    BOOL ret = FALSE, setup_fs_hack = FALSE;
+     struct gl_drawable *draw_gl, *read_gl = NULL;
+ 
+     TRACE("(%p,%p,%p)\n", draw_hdc, read_hdc, ctx);
+@@ -1889,11 +2205,18 @@ static BOOL X11DRV_wglMakeContextCurrentARB( HDC draw_hdc, HDC read_hdc, struct
+                                      read_gl ? read_gl->drawable : 0, ctx->ctx);
+         if (ret)
+         {
+-            ctx->has_been_current = TRUE;
++            NtCurrentTeb()->glContext = ctx;
++            if (ctx->fs_hack != draw_gl->fs_hack || (ctx->fs_hack && ctx->drawables[0] != draw_gl))
++                setup_fs_hack = TRUE;
+             ctx->hdc = draw_hdc;
+             set_context_drawables( ctx, draw_gl, read_gl );
+             ctx->refresh_drawables = FALSE;
+-            NtCurrentTeb()->glContext = ctx;
++            if (setup_fs_hack)
++            {
++                ctx->fs_hack = draw_gl->fs_hack;
++                fs_hack_setup_context( ctx, draw_gl );
++            }
++            ctx->has_been_current = TRUE;
+             LeaveCriticalSection( &context_section );
+             goto done;
+         }
+@@ -1950,12 +2273,135 @@ static BOOL glxdrv_wglShareLists(struct wgl_context *org, struct wgl_context *de
+     return FALSE;
+ }
+ 
++static void wglBindFramebuffer( GLenum target, GLuint framebuffer )
++{
++    struct wgl_context *ctx = NtCurrentTeb()->glContext;
++
++    TRACE( "target %#x, framebuffer %u\n", target, framebuffer );
++    if (ctx->fs_hack && !framebuffer)
++        framebuffer = ctx->fs_hack_fbo;
++
++    if (target == GL_DRAW_FRAMEBUFFER || target == GL_FRAMEBUFFER)
++        ctx->current_draw_fbo = framebuffer;
++    if (target == GL_READ_FRAMEBUFFER || target == GL_FRAMEBUFFER)
++        ctx->current_read_fbo = framebuffer;
++
++    pglBindFramebuffer( target, framebuffer );
++}
++
++static void wglBindFramebufferEXT( GLenum target, GLuint framebuffer )
++{
++    struct wgl_context *ctx = NtCurrentTeb()->glContext;
++
++    TRACE( "target %#x, framebuffer %u\n", target, framebuffer );
++    if (ctx->fs_hack && !framebuffer)
++        framebuffer = ctx->fs_hack_fbo;
++
++    if (target == GL_DRAW_FRAMEBUFFER || target == GL_FRAMEBUFFER)
++        ctx->current_draw_fbo = framebuffer;
++    if (target == GL_READ_FRAMEBUFFER || target == GL_FRAMEBUFFER)
++        ctx->current_read_fbo = framebuffer;
++
++    pglBindFramebufferEXT( target, framebuffer );
++}
++
++static void wglDrawBuffer( GLenum buffer )
++{
++    struct wgl_context *ctx = NtCurrentTeb()->glContext;
++
++    if (ctx->fs_hack && ctx->current_draw_fbo == ctx->fs_hack_fbo)
++    {
++        TRACE("Overriding %#x with GL_COLOR_ATTACHMENT0\n", buffer);
++        buffer = GL_COLOR_ATTACHMENT0;
++    }
++    pglDrawBuffer( buffer );
++}
++
++static void wglReadBuffer( GLenum buffer )
++{
++    struct wgl_context *ctx = NtCurrentTeb()->glContext;
++
++    if (ctx->fs_hack && ctx->current_read_fbo == ctx->fs_hack_fbo)
++    {
++        TRACE("Overriding %#x with GL_COLOR_ATTACHMENT0\n", buffer);
++        buffer = GL_COLOR_ATTACHMENT0;
++    }
++    pglReadBuffer( buffer );
++}
++
++static void fs_hack_blit_framebuffer( struct gl_drawable *gl, GLenum draw_buffer )
++{
++    struct wgl_context *ctx = NtCurrentTeb()->glContext;
++    POINT scaled = fs_hack_get_scaled_screen_size();
++    GLuint prev_draw_fbo, prev_read_fbo;
++    GLint prev_scissor[4];
++    POINT src = fs_hack_current_mode();
++    POINT real = fs_hack_real_mode();
++    POINT scaled_origin = {0, 0};
++    float prev_clear_color[4];
++
++    fs_hack_user_to_real(&scaled_origin);
++
++    if(ctx->setup_for.x != src.x ||
++            ctx->setup_for.y != src.y)
++        fs_hack_setup_context( ctx, gl );
++
++    TRACE( "Blitting from FBO %u %ux%u to %ux%u\n", ctx->fs_hack_fbo, src.x, src.y, scaled.x, scaled.y );
++
++    opengl_funcs.gl.p_glGetIntegerv( GL_DRAW_FRAMEBUFFER_BINDING, (GLint *)&prev_draw_fbo );
++    opengl_funcs.gl.p_glGetIntegerv( GL_READ_FRAMEBUFFER_BINDING, (GLint *)&prev_read_fbo );
++    TRACE( "Previous draw FBO %u, read FBO %u\n", prev_draw_fbo, prev_read_fbo );
++
++    if(gl->has_scissor_indexed){
++        opengl_funcs.ext.p_glGetIntegeri_v(GL_SCISSOR_BOX, 0, prev_scissor);
++        opengl_funcs.ext.p_glScissorIndexed(0, 0, 0, real.x, real.y);
++    }else{
++        opengl_funcs.gl.p_glGetIntegerv(GL_SCISSOR_BOX, prev_scissor);
++        opengl_funcs.gl.p_glScissor(0, 0, real.x, real.y);
++    }
++
++    pglBindFramebuffer( GL_READ_FRAMEBUFFER, ctx->fs_hack_fbo );
++    if (ctx->fs_hack_color_resolve_renderbuffer)
++    {
++        pglBindFramebuffer( GL_DRAW_FRAMEBUFFER, ctx->fs_hack_resolve_fbo );
++        pglBlitFramebuffer( 0, 0, src.x, src.y, 0, 0, src.x, src.y, GL_COLOR_BUFFER_BIT, GL_NEAREST );
++        pglBindFramebuffer( GL_READ_FRAMEBUFFER, ctx->fs_hack_resolve_fbo );
++    }
++    pglBindFramebuffer( GL_DRAW_FRAMEBUFFER, 0 );
++
++    //HACK
++    //pglDrawBuffer( draw_buffer );
++    pglDrawBuffer( GL_BACK );
++
++    opengl_funcs.gl.p_glGetFloatv( GL_COLOR_CLEAR_VALUE, prev_clear_color );
++    opengl_funcs.gl.p_glClearColor( 0.0f, 0.0f, 0.0f, 1.0f );
++    opengl_funcs.gl.p_glClear( GL_COLOR_BUFFER_BIT );
++    opengl_funcs.gl.p_glClearColor( prev_clear_color[0], prev_clear_color[1], prev_clear_color[2], prev_clear_color[3] );
++
++    pglBlitFramebuffer( 0, 0, src.x, src.y, scaled_origin.x, scaled_origin.y, scaled_origin.x + scaled.x, scaled_origin.y + scaled.y, GL_COLOR_BUFFER_BIT, GL_LINEAR );
++    //HACK
++    if ( draw_buffer == GL_FRONT )
++        pglXSwapBuffers(gdi_display, gl->drawable);
++
++    if(gl->has_scissor_indexed){
++        opengl_funcs.ext.p_glScissorIndexedv(0, prev_scissor);
++    }else{
++        opengl_funcs.gl.p_glScissor(prev_scissor[0], prev_scissor[1],
++                prev_scissor[2], prev_scissor[3]);
++    }
++
++    pglBindFramebuffer( GL_DRAW_FRAMEBUFFER, prev_draw_fbo );
++    pglBindFramebuffer( GL_READ_FRAMEBUFFER, prev_read_fbo );
++}
++
+ static void wglFinish(void)
+ {
+     struct x11drv_escape_flush_gl_drawable escape;
+     struct gl_drawable *gl;
+     struct wgl_context *ctx = NtCurrentTeb()->glContext;
+ 
++    TRACE("\n");
++
+     escape.code = X11DRV_FLUSH_GL_DRAWABLE;
+     escape.gl_drawable = 0;
+     escape.flush = FALSE;
+@@ -1969,6 +2415,18 @@ static void wglFinish(void)
+         default: break;
+         }
+         sync_context(ctx);
++
++        if (gl->fs_hack) {
++            ctx->fs_hack = gl->fs_hack;
++            if(!gl->fs_hack_context_set_up)
++                fs_hack_setup_context( ctx, gl );
++            if(!gl->fs_hack_did_swapbuf)
++                fs_hack_blit_framebuffer( gl, GL_FRONT );
++        }else if(gl->fs_hack_context_set_up){
++            ctx->fs_hack = FALSE;
++            fs_hack_setup_context(ctx, gl);
++        }
++
+         release_gl_drawable( gl );
+     }
+ 
+@@ -1982,6 +2440,8 @@ static void wglFlush(void)
+     struct gl_drawable *gl;
+     struct wgl_context *ctx = NtCurrentTeb()->glContext;
+ 
++    TRACE("\n");
++
+     escape.code = X11DRV_FLUSH_GL_DRAWABLE;
+     escape.gl_drawable = 0;
+     escape.flush = FALSE;
+@@ -1995,9 +2455,20 @@ static void wglFlush(void)
+         default: break;
+         }
+         sync_context(ctx);
++
++        if (gl->fs_hack) {
++            ctx->fs_hack = gl->fs_hack;
++            if(!gl->fs_hack_context_set_up)
++                fs_hack_setup_context( ctx, gl );
++            if(!gl->fs_hack_did_swapbuf)
++                fs_hack_blit_framebuffer( gl, GL_FRONT );
++        }else if(gl->fs_hack_context_set_up){
++            ctx->fs_hack = FALSE;
++            fs_hack_setup_context(ctx, gl);
++        }
++
+         release_gl_drawable( gl );
+     }
+-
+     pglFlush();
+     if (escape.gl_drawable) ExtEscape( ctx->hdc, X11DRV_ESCAPE, sizeof(escape), (LPSTR)&escape, 0, NULL );
+ }
+@@ -3319,6 +3790,16 @@ static BOOL glxdrv_wglSwapBuffers( HDC hdc )
+             target_sbc = pglXSwapBuffersMscOML( gdi_display, gl->drawable, 0, 0, 0 );
+             break;
+         }
++        if (gl->fs_hack){
++            ctx->fs_hack = gl->fs_hack;
++            if(!gl->fs_hack_context_set_up)
++                fs_hack_setup_context( ctx, gl );
++            fs_hack_blit_framebuffer( gl, GL_BACK );
++            gl->fs_hack_did_swapbuf = TRUE;
++        }else if(gl->fs_hack_context_set_up){
++            ctx->fs_hack = FALSE;
++            fs_hack_setup_context(ctx, gl);
++        }
+         pglXSwapBuffers(gdi_display, gl->drawable);
+         break;
+     }
+diff --git a/dlls/winex11.drv/settings.c b/dlls/winex11.drv/settings.c
+index fc9d29c23e..25eef67165 100644
+--- a/dlls/winex11.drv/settings.c
++++ b/dlls/winex11.drv/settings.c
+@@ -131,27 +131,216 @@ unsigned int X11DRV_Settings_GetModeCount(void)
+  * Default handlers if resolution switching is not enabled
+  *
+  */
++static int currentMode = 0;
++double fs_hack_user_to_real_w = 1., fs_hack_user_to_real_h = 1.;
++double fs_hack_real_to_user_w = 1., fs_hack_real_to_user_h = 1.;
++static int offs_x = 0, offs_y = 0;
++static int fs_width = 0, fs_height = 0;
++
+ static int X11DRV_nores_GetCurrentMode(void)
+ {
+-    return 0;
++    return currentMode;
++}
++
++static struct fs_mode {
++    int w, h;
++} fs_modes[] = {
++    {0, 0}, /* mode 0 is the real mode */
++    { 640,  480}, /*  4:3 */
++    { 800,  600}, /*  4:3 */
++    {1024,  768}, /*  4:3 */
++    {1152,  864}, /*  4:3 */
++    {1280,  720}, /* 16:9 */
++    {1280,  800}, /*  8:5 */
++    {1280,  960}, /*  4:3 */
++    {1280, 1024}, /*  5:4 */
++    {1366,  768}, /* 16:9 */
++    {1400, 1050}, /*  4:3 */
++    {1440,  900}, /*  4:3 */
++    {1600,  900}, /* 16:9 */
++    {1600, 1200}, /*  4:3 */
++    {1680, 1050}, /*  8:5 */
++    {1920, 1080}, /* 16:9 */
++    {1920, 1200}, /*  8:5 */
++};
++
++BOOL fs_hack_enabled(void)
++{
++    return currentMode != 0;
++}
++
++BOOL fs_hack_matches_current_mode(int w, int h)
++{
++    return fs_hack_enabled() &&
++        (w == dd_modes[currentMode].width &&
++         h == dd_modes[currentMode].height);
++}
++
++BOOL fs_hack_matches_real_mode(int w, int h)
++{
++    return fs_hack_enabled() &&
++        (w == fs_modes[0].w &&
++         h == fs_modes[0].h);
++}
++
++BOOL fs_hack_matches_last_mode(int w, int h)
++{
++    return w == fs_width && h == fs_height;
++}
++
++void fs_hack_scale_user_to_real(POINT *pos)
++{
++    if(fs_hack_enabled()){
++        TRACE("from %d,%d\n", pos->x, pos->y);
++        pos->x *= fs_hack_user_to_real_w;
++        pos->y *= fs_hack_user_to_real_h;
++        TRACE("to %d,%d\n", pos->x, pos->y);
++    }
++}
++
++void fs_hack_scale_real_to_user(POINT *pos)
++{
++    if(fs_hack_enabled()){
++        TRACE("from %d,%d\n", pos->x, pos->y);
++        pos->x *= fs_hack_real_to_user_w;
++        pos->y *= fs_hack_real_to_user_h;
++        TRACE("to %d,%d\n", pos->x, pos->y);
++    }
++}
++
++POINT fs_hack_get_scaled_screen_size(void)
++{
++    POINT p = { dd_modes[currentMode].width,
++        dd_modes[currentMode].height };
++    fs_hack_scale_user_to_real(&p);
++    return p;
++}
++
++void fs_hack_user_to_real(POINT *pos)
++{
++    if(fs_hack_enabled()){
++        TRACE("from %d,%d\n", pos->x, pos->y);
++        fs_hack_scale_user_to_real(pos);
++        pos->x += offs_x;
++        pos->y += offs_y;
++        TRACE("to %d,%d\n", pos->x, pos->y);
++    }
++}
++
++void fs_hack_real_to_user(POINT *pos)
++{
++    if(fs_hack_enabled()){
++        TRACE("from %d,%d\n", pos->x, pos->y);
++
++        if(pos->x <= offs_x)
++            pos->x = 0;
++        else
++            pos->x -= offs_x;
++
++        if(pos->y <= offs_y)
++            pos->y = 0;
++        else
++            pos->y -= offs_y;
++
++        if(pos->x >= fs_width)
++            pos->x = fs_width - 1;
++        if(pos->y >= fs_height)
++            pos->y = fs_height - 1;
++
++        fs_hack_scale_real_to_user(pos);
++
++        TRACE("to %d,%d\n", pos->x, pos->y);
++    }
+ }
+ 
+ static LONG X11DRV_nores_SetCurrentMode(int mode)
+ {
+-    if (mode == 0) return DISP_CHANGE_SUCCESSFUL;
+-    TRACE("Ignoring mode change request mode=%d\n", mode);
+-    return DISP_CHANGE_FAILED;
++    if (mode >= dd_mode_count)
++       return DISP_CHANGE_FAILED;
++
++    currentMode = mode;
++    TRACE("set current mode to: %ux%u\n",
++            dd_modes[currentMode].width,
++            dd_modes[currentMode].height);
++    if(currentMode == 0){
++        fs_hack_user_to_real_w = 1.;
++        fs_hack_user_to_real_h = 1.;
++        fs_hack_real_to_user_w = 1.;
++        fs_hack_real_to_user_h = 1.;
++        offs_x = offs_y = 0;
++        fs_width = dd_modes[currentMode].width;
++        fs_height = dd_modes[currentMode].height;
++
++        X11DRV_resize_desktop(
++                DisplayWidth(gdi_display, default_visual.screen),
++                DisplayHeight(gdi_display, default_visual.screen));
++    }else{
++        double w = dd_modes[currentMode].width;
++        double h = dd_modes[currentMode].height;
++        if(fs_modes[0].w / (double)fs_modes[0].h < w / h){ /* real mode is narrower than fake mode */
++            /* scale to fit width */
++            h = fs_modes[0].w * (h / w);
++            w = fs_modes[0].w;
++            offs_x = 0;
++            offs_y = (fs_modes[0].h - h) / 2;
++            fs_width = fs_modes[0].w;
++            fs_height = (int)h;
++        }else{
++            /* scale to fit height */
++            w = fs_modes[0].h * (w / h);
++            h = fs_modes[0].h;
++            offs_x = (fs_modes[0].w - w) / 2;
++            offs_y = 0;
++            fs_width = (int)w;
++            fs_height = fs_modes[0].h;
++        }
++        fs_hack_user_to_real_w = w / (double)dd_modes[currentMode].width;
++        fs_hack_user_to_real_h = h / (double)dd_modes[currentMode].height;
++        fs_hack_real_to_user_w = dd_modes[currentMode].width / (double)w;
++        fs_hack_real_to_user_h = dd_modes[currentMode].height / (double)h;
++
++        X11DRV_resize_desktop(
++                DisplayWidth(gdi_display, default_visual.screen) - (dd_modes[0].width - w),
++                DisplayHeight(gdi_display, default_visual.screen) - (dd_modes[0].height - h));
++    }
++
++    return DISP_CHANGE_SUCCESSFUL;
++}
++
++POINT fs_hack_current_mode(void)
++{
++    POINT ret = { dd_modes[currentMode].width,
++        dd_modes[currentMode].height };
++    return ret;
++}
++
++POINT fs_hack_real_mode(void)
++{
++    POINT ret = { dd_modes[0].width,
++        dd_modes[0].height };
++    return ret;
+ }
+ 
+-/* default handler only gets the current X desktop resolution */
+ void X11DRV_Settings_Init(void)
+ {
++    int i;
+     RECT primary = get_primary_monitor_rect();
+     X11DRV_Settings_SetHandlers("NoRes", 
+                                 X11DRV_nores_GetCurrentMode, 
+                                 X11DRV_nores_SetCurrentMode, 
+-                                1, 0);
+-    X11DRV_Settings_AddOneMode( primary.right - primary.left, primary.bottom - primary.top, 0, 60);
++                                sizeof(fs_modes) / sizeof(struct fs_mode), 1);
++    fs_modes[0].w = primary.right - primary.left;
++    fs_modes[0].h = primary.bottom - primary.top;
++    for(i = 0; i < sizeof(fs_modes) / sizeof(struct fs_mode); ++i){
++        if(i > 0 &&
++                ((fs_modes[i].w == fs_modes[0].w &&
++                  fs_modes[i].h == fs_modes[0].h) ||
++                 (fs_modes[i].w > fs_modes[0].w ||
++                  fs_modes[i].h > fs_modes[0].h)))
++            continue;
++        X11DRV_Settings_AddOneMode( fs_modes[i].w, fs_modes[i].h, 0, 60);
++    }
++    X11DRV_Settings_AddDepthModes();
+ }
+ 
+ static BOOL get_display_device_reg_key(char *key, unsigned len)
+diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
+index 447f294342..6da8893964 100644
+--- a/dlls/winex11.drv/window.c
++++ b/dlls/winex11.drv/window.c
+@@ -354,6 +354,11 @@ static void sync_window_region( struct x11drv_win_data *data, HRGN win_region )
+     HRGN hrgn = win_region;
+ 
+     if (!data->whole_window) return;
++
++    if(data->fs_hack){
++        ERR("shaped windows with fs hack not supported, things may go badly\n");
++    }
++
+     data->shaped = FALSE;
+ 
+     if (IsRectEmpty( &data->window_rect ))  /* set an empty shape */
+@@ -725,6 +730,13 @@ static void set_mwm_hints( struct x11drv_win_data *data, DWORD style, DWORD ex_s
+     XChangeProperty( data->display, data->whole_window, x11drv_atom(_MOTIF_WM_HINTS),
+                      x11drv_atom(_MOTIF_WM_HINTS), 32, PropModeReplace,
+                      (unsigned char*)&mwm_hints, sizeof(mwm_hints)/sizeof(long) );
++
++    if (GetFocus() == data->hwnd)
++    {
++        /* workaround for mutter gitlab bug #273 */
++        TRACE("workaround mutter bug, setting take_focus_back\n");
++        data->take_focus_back = GetTickCount64();
++    }
+ }
+ 
+ 
+@@ -938,7 +950,7 @@ void update_net_wm_states( struct x11drv_win_data *data )
+     style = GetWindowLongW( data->hwnd, GWL_STYLE );
+     if (style & WS_MINIMIZE)
+         new_state |= data->net_wm_state & ((1 << NET_WM_STATE_FULLSCREEN)|(1 << NET_WM_STATE_MAXIMIZED));
+-    if (is_window_rect_fullscreen( &data->whole_rect ))
++    if ((!data->fs_hack || fs_hack_enabled()) && is_window_rect_fullscreen( &data->whole_rect ))
+     {
+         if ((style & WS_MAXIMIZE) && (style & WS_CAPTION) == WS_CAPTION)
+             new_state |= (1 << NET_WM_STATE_MAXIMIZED);
+@@ -1011,6 +1023,12 @@ void update_net_wm_states( struct x11drv_win_data *data )
+     XChangeProperty( data->display, data->whole_window, x11drv_atom(_NET_WM_BYPASS_COMPOSITOR), XA_CARDINAL,
+                      32, PropModeReplace, (unsigned char *)&net_wm_bypass_compositor, 1 );
+ 
++    if(new_state & (1 << NET_WM_STATE_FULLSCREEN))
++        XSetInputFocus( data->display, data->whole_window, RevertToParent, CurrentTime );
++
++    XChangeProperty( data->display, data->whole_window, x11drv_atom(_NET_WM_BYPASS_COMPOSITOR), XA_CARDINAL,
++                     32, PropModeReplace, (unsigned char *)&net_wm_bypass_compositor, 1 );
++
+ }
+ 
+ /***********************************************************************
+@@ -1226,8 +1244,14 @@ static void sync_window_position( struct x11drv_win_data *data,
+     /* resizing a managed maximized window is not allowed */
+     if (!(style & WS_MAXIMIZE) || !data->managed)
+     {
+-        changes.width = data->whole_rect.right - data->whole_rect.left;
+-        changes.height = data->whole_rect.bottom - data->whole_rect.top;
++        if(data->fs_hack){
++            POINT p = fs_hack_real_mode();
++            changes.width = p.x;
++            changes.height = p.y;
++        }else{
++            changes.width = data->whole_rect.right - data->whole_rect.left;
++            changes.height = data->whole_rect.bottom - data->whole_rect.top;
++        }
+         /* if window rect is empty force size to 1x1 */
+         if (changes.width <= 0 || changes.height <= 0) changes.width = changes.height = 1;
+         if (changes.width > 65535) changes.width = 65535;
+@@ -1309,6 +1333,15 @@ static void sync_client_position( struct x11drv_win_data *data,
+     if (changes.width  != old_client_rect->right - old_client_rect->left) mask |= CWWidth;
+     if (changes.height != old_client_rect->bottom - old_client_rect->top) mask |= CWHeight;
+ 
++    if(data->fs_hack){
++        POINT p = fs_hack_real_mode();
++        changes.x = 0;
++        changes.y = 0;
++        changes.width = p.x;
++        changes.height = p.y;
++        mask = CWX | CWY | CWWidth | CWHeight;
++    }
++
+     if (mask)
+     {
+         TRACE( "setting client win %lx pos %d,%d,%dx%d changes=%x\n",
+@@ -1462,6 +1495,14 @@ Window create_client_window( HWND hwnd, const XVisualInfo *visual )
+     cx = min( max( 1, data->client_rect.right - data->client_rect.left ), 65535 );
+     cy = min( max( 1, data->client_rect.bottom - data->client_rect.top ), 65535 );
+ 
++
++    if(data->fs_hack){
++        POINT p = fs_hack_real_mode();
++        cx = p.x;
++        cy = p.y;
++    }
++
++    TRACE("setting client rect: %u, %u x %ux%u\n", x, y, cx, cy);
+     ret = data->client_window = XCreateWindow( gdi_display,
+                                                data->whole_window ? data->whole_window : dummy_parent,
+                                                x, y, cx, cy, 0, default_visual.depth, InputOutput,
+@@ -1514,11 +1555,20 @@ static void create_whole_window( struct x11drv_win_data *data )
+ 
+     mask = get_window_attributes( data, &attr );
+ 
++    attr.background_pixel = XBlackPixel(data->display, data->vis.screen);
++    mask |= CWBackPixel;
++
+     if (!(cx = data->whole_rect.right - data->whole_rect.left)) cx = 1;
+     else if (cx > 65535) cx = 65535;
+     if (!(cy = data->whole_rect.bottom - data->whole_rect.top)) cy = 1;
+     else if (cy > 65535) cy = 65535;
+ 
++    if(data->fs_hack){
++        POINT p = fs_hack_real_mode();
++        cx = p.x;
++        cy = p.y;
++    }
++
+     pos = virtual_screen_to_root( data->whole_rect.left, data->whole_rect.top );
+     data->whole_window = XCreateWindow( data->display, root_window, pos.x, pos.y,
+                                         cx, cy, 0, data->vis.depth, InputOutput,
+@@ -2274,6 +2324,26 @@ static inline BOOL get_surface_rect( const RECT *visible_rect, RECT *surface_rec
+ }
+ 
+ 
++BOOL fs_hack_window_is_hacked(HWND hwnd, struct x11drv_win_data *data)
++{
++    BOOL release = FALSE, ret;
++
++    if(!data){
++        data = get_win_data(hwnd);
++        if(!data)
++            return FALSE;
++        release = TRUE;
++    }
++
++    ret = data->fs_hack;
++
++    if(release)
++        release_win_data(data);
++
++    return ret;
++}
++
++
+ /***********************************************************************
+  *		WindowPosChanging   (X11DRV.@)
+  */
+@@ -2289,6 +2359,35 @@ void CDECL X11DRV_WindowPosChanging( HWND hwnd, HWND insert_after, UINT swp_flag
+ 
+     if (!data && !(data = X11DRV_create_win_data( hwnd, window_rect, client_rect ))) return;
+ 
++    if(!data->fs_hack &&
++            fs_hack_matches_current_mode(
++                window_rect->right - window_rect->left,
++                window_rect->bottom - window_rect->top)){
++        POINT tl = virtual_screen_to_root(0, 0);
++        POINT p = fs_hack_real_mode();
++        TRACE("Enabling fs hack, resizing the window to (%u,%u)-(%u,%u)\n", tl.x, tl.y, p.x, p.y);
++        data->fs_hack = TRUE;
++        XMoveResizeWindow(data->display, data->whole_window, tl.x, tl.y, p.x, p.y);
++        if(data->client_window)
++            XMoveResizeWindow(data->display, data->client_window, 0, 0, p.x, p.y);
++    }else if(data->fs_hack &&
++            !fs_hack_matches_current_mode(
++                window_rect->right - window_rect->left,
++                window_rect->bottom - window_rect->top)){
++        TRACE("Disabling fs hack\n");
++        data->fs_hack = FALSE;
++        XMoveResizeWindow(data->display, data->whole_window,
++                window_rect->left, window_rect->top,
++                window_rect->right - window_rect->left,
++                window_rect->bottom - window_rect->top);
++        if(data->client_window){
++            XMoveResizeWindow(data->display, data->client_window,
++                    data->client_rect.left, data->client_rect.top,
++                    data->client_rect.right - data->client_rect.left,
++                    data->client_rect.bottom - data->client_rect.top);
++        }
++    }
++
+     /* check if we need to switch the window to managed */
+     if (!data->managed && data->whole_window && is_window_managed( hwnd, swp_flags, window_rect ))
+     {
+@@ -2423,6 +2522,9 @@ void CDECL X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, UINT swp_flags
+         return;
+     }
+ 
++    if (data->fs_hack)
++        sync_gl_drawable( hwnd );
++
+     /* check if we are currently processing an event relevant to this window */
+     event_type = 0;
+     if (thread_data &&
+@@ -2547,7 +2649,16 @@ UINT CDECL X11DRV_ShowWindow( HWND hwnd, INT cmd, RECT *rect, UINT swp )
+                   &root, &x, &y, &width, &height, &border, &depth );
+     XTranslateCoordinates( thread_data->display, data->whole_window, root, 0, 0, &x, &y, &top );
+     pos = root_to_virtual_screen( x, y );
+-    X11DRV_X_to_window_rect( data, rect, pos.x, pos.y, width, height );
++    if(data->fs_hack){
++        POINT p = fs_hack_current_mode();
++        rect->left = 0;
++        rect->top = 0;
++        rect->right = p.x;
++        rect->bottom = p.y;
++        X11DRV_X_to_window_rect( data, rect, 0, 0, p.x, p.y );
++    }else{
++        X11DRV_X_to_window_rect( data, rect, pos.x, pos.y, width, height );
++    }
+     swp &= ~(SWP_NOMOVE | SWP_NOCLIENTMOVE | SWP_NOSIZE | SWP_NOCLIENTSIZE);
+ 
+ done:
+diff --git a/dlls/winex11.drv/x11drv.h b/dlls/winex11.drv/x11drv.h
+index 6eb66c8fed..0a62d753ac 100644
+--- a/dlls/winex11.drv/x11drv.h
++++ b/dlls/winex11.drv/x11drv.h
+@@ -308,6 +308,7 @@ struct x11drv_escape_flush_gl_drawable
+     enum x11drv_escape_codes code;         /* escape code (X11DRV_FLUSH_GL_DRAWABLE) */
+     Drawable                 gl_drawable;  /* GL drawable */
+     BOOL                     flush;        /* flush X11 before copying */
++    BOOL                     fs_hack;
+ };
+ 
+ /**************************************************************************
+@@ -573,6 +574,8 @@ struct x11drv_win_data
+     BOOL        shaped : 1;     /* is window using a custom region shape? */
+     BOOL        layered : 1;    /* is window layered and with valid attributes? */
+     BOOL        use_alpha : 1;  /* does window use an alpha channel? */
++    BOOL        fs_hack : 1;
++    ULONGLONG   take_focus_back;
+     int         wm_state;       /* current value of the WM_STATE property */
+     DWORD       net_wm_state;   /* bit mask of active x11drv_net_wm_state values */
+     Window      embedder;       /* window id of embedder */
+@@ -607,6 +610,22 @@ extern void update_systray_balloon_position(void) DECLSPEC_HIDDEN;
+ extern HWND create_foreign_window( Display *display, Window window ) DECLSPEC_HIDDEN;
+ extern BOOL update_clipboard( HWND hwnd ) DECLSPEC_HIDDEN;
+ 
++extern BOOL fs_hack_enabled(void) DECLSPEC_HIDDEN;
++extern BOOL fs_hack_matches_current_mode(int w, int h) DECLSPEC_HIDDEN;
++extern BOOL fs_hack_matches_real_mode(int w, int h) DECLSPEC_HIDDEN;
++extern POINT fs_hack_current_mode(void) DECLSPEC_HIDDEN;
++extern POINT fs_hack_real_mode(void) DECLSPEC_HIDDEN;
++extern void fs_hack_user_to_real(POINT *pos) DECLSPEC_HIDDEN;
++extern void fs_hack_real_to_user(POINT *pos) DECLSPEC_HIDDEN;
++extern void fs_hack_scale_user_to_real(POINT *pos) DECLSPEC_HIDDEN;
++extern void fs_hack_scale_real_to_user(POINT *pos) DECLSPEC_HIDDEN;
++extern POINT fs_hack_get_scaled_screen_size(void) DECLSPEC_HIDDEN;
++extern BOOL fs_hack_window_is_hacked(HWND hwnd, struct x11drv_win_data *data) DECLSPEC_HIDDEN;
++extern void fs_hack_xrender_copy(Drawable src, Drawable dst) DECLSPEC_HIDDEN;
++extern double fs_hack_user_to_real_w, fs_hack_user_to_real_h DECLSPEC_HIDDEN;
++extern double fs_hack_real_to_user_w, fs_hack_real_to_user_h DECLSPEC_HIDDEN;
++BOOL fs_hack_matches_last_mode(int w, int h) DECLSPEC_HIDDEN;
++
+ static inline void mirror_rect( const RECT *window_rect, RECT *rect )
+ {
+     int width = window_rect->right - window_rect->left;
+diff --git a/dlls/winex11.drv/x11drv_main.c b/dlls/winex11.drv/x11drv_main.c
+index 10b5d95715..5a98ab1e99 100644
+--- a/dlls/winex11.drv/x11drv_main.c
++++ b/dlls/winex11.drv/x11drv_main.c
+@@ -63,8 +63,8 @@ Colormap default_colormap = None;
+ XPixmapFormatValues **pixmap_formats;
+ unsigned int screen_bpp;
+ Window root_window;
+-BOOL usexvidmode = TRUE;
+-BOOL usexrandr = TRUE;
++BOOL usexvidmode = FALSE;
++BOOL usexrandr = FALSE;
+ BOOL usexcomposite = TRUE;
+ BOOL use_xkb = TRUE;
+ BOOL use_take_focus = TRUE;
+diff --git a/dlls/winex11.drv/xinerama.c b/dlls/winex11.drv/xinerama.c
+index 7b8bc8bafb..417810fe2c 100644
+--- a/dlls/winex11.drv/xinerama.c
++++ b/dlls/winex11.drv/xinerama.c
+@@ -165,6 +165,14 @@ static int query_screens(void)
+             snprintfW( monitors[i].szDevice, sizeof(monitors[i].szDevice) / sizeof(WCHAR),
+                        monitor_deviceW, (monitors[i].dwFlags & MONITORINFOF_PRIMARY) ? 1 : device++ );
+         }
++
++        if(fs_hack_enabled()){
++            POINT fs = fs_hack_current_mode();
++            MONITORINFOEXW *primary = get_primary();
++            primary->rcMonitor.right = primary->rcMonitor.left + fs.x;
++            primary->rcMonitor.bottom = primary->rcMonitor.top + fs.y;
++            primary->rcWork = primary->rcMonitor;
++        }
+     }
+     else count = 0;
+ 


### PR DESCRIPTION
#44 The PR adds the patches used by Valve's Proton WINE fork in order to prevent games from changing the desktop resolution of the system when adjusting in-game resolution
The patch only applies to wine-staging and not base-wine.
Also it does not work in combination with Gallium Nine or any game with a native Vulkan renderer.
The patch has been tested with Shadow Warrior 2 and Overwatch using DXVK