### PR TITLE
[Wine-tkg PKGBUILD] PKGNAME_OVERRIDE improvements

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -59,7 +59,7 @@ else
 fi
 
 if [ -n "$_PKGNAME_OVERRIDE" ]; then
-  pkgname="${pkgname}-${_PKGNAME_OVERRIDE}"
+  pkgname="${_PKGNAME_OVERRIDE}"
   msg2 "Overriding default pkgname. New pkgname: ${pkgname}"
 else
   if [[ $_use_staging == "true" ]]; then


### PR DESCRIPTION
Hi!
Make it free to choose a package name when using PKGNAME_OVERRIDE. For example, I may be want that the pkgname be just "wine-tkg-git" and without some additions like "wine-tkg-git-some-any-needless-words". It would not be superfluous to make such a feature in the config file.
Thank you!