### PR TITLE
Customization improvements

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -116,7 +116,7 @@ _staging_pulse_disable="false"
 # CSMT toggle patch - Corrects the CSMT toggle to be more logical - https://github.com/wine-staging/wine-staging/pull/60/commits/ad474559590a659b3df72ec9965de20c7f51c3a8
 _CSMT_toggle="true"
 
-# GLSL toggle patch - Requires staging. Gives the ability to use ARB shaders in winecfg, noticable stutter reduction with games using wined3d.
+# GLSL toggle patch - Requires staging, ignored if Gallium Nine is used. Gives the ability to use ARB shaders in winecfg, noticable stutter reduction with games using wined3d.
 _GLSL_toggle="true"
 
 # steam crossover hack for store/web functionality - https://bugs.winehq.org/show_bug.cgi?id=39403

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -140,8 +140,8 @@ _proton_fs_hack="false"
 # Partial fix for systray on plasma 5 - https://bugs.winehq.org/show_bug.cgi?id=38409
 _plasma_systray_fix="false"
 
-# IMAGE_FILE_LARGE_ADDRESS_AWARE override - Useful for 32-bit games hitting address space limitations - Enable with WINE_LARGE_ADDRESS_AWARE=1
-_large_address_aware="true"
+# IMAGE_FILE_LARGE_ADDRESS_AWARE override - Requires 3.19 or higher - Useful for 32-bit games hitting address space limitations - Enable with WINE_LARGE_ADDRESS_AWARE=1
+_large_address_aware="false"
 
 
 #### USER PATCHES ####

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -59,7 +59,7 @@ _use_staging="true"
 # Leave empty to use latest master - https://github.com/wine-staging/wine-staging/commits/master
 _staging_version=""
 
-# pba - Enable with PBA_ENABLE=1 envvar
+# pba - Enable with PBA_ENABLE=1 envvar, 3.16 recommended, broken on 3.19 and higher
 _use_pba="false"
 
 # vkd3d - Use the currently installed vkd3d packages (both 32 and 64-bit) for d3d12 to vulkan translation - If they aren't (both) installed, vkd3d won't be used - Cannot be used with dxvk


### PR DESCRIPTION
Orginally about IMAGE_FILE_LARGE_ADDRESS_AWARE failing if WINE is not >=3.19
**3.17:**
```  -I../../../../wine-git/dlls/nvapi/tests -I../../../include -I../../../..
git/include \
  -D__WINESRC__ -D_REENTRANT -fPIC -Wall -pipe -fno-strict-aliasing -Wdecl
n-after-statement \
  -Wempty-body -Wignored-qualifiers -Wno-packed-not-aligned -Wshift-overfl
Wstrict-prototypes \
  -Wtype-limits -Wunused-but-set-parameter -Wvla -Wwrite-strings -Wpointer
 -Wlogical-op \
  -D_FORTIFY_SOURCE=2 -march=native -pipe -Os -U_FORTIFY_SOURCE -D_FORTIFY
E=0
gcc -m64 -c -o testlist.o testlist.c -I. -I../../../../wine-git/dlls/nvapi
 -I../../../include \
  -I../../../../wine-git/include -D__WINESRC__ -D_REENTRANT -fPIC -Wall -p
no-strict-aliasing \
  -Wdeclaration-after-statement -Wempty-body -Wignored-qualifiers -Wno-pac
t-aligned \
  -Wshift-overflow=2 -Wstrict-prototypes -Wtype-limits -Wunused-but-set-pa
r -Wvla \
  -Wwrite-strings -Wpointer-arith -Wlogical-op -D_FORTIFY_SOURCE=2 -march=
 -pipe -Os -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
../../../tools/winegcc/winegcc -s -o nvapi_test-stripped.exe.so -B../../..
/winebuild -m64 \
  -fasynchronous-unwind-tables -Wb,-F,nvapi_test.exe nvapi.o testlist.o -l
 -lshlwapi -ld3d9 \
  -Os
../../../wine-git/dlls/ntdll/loader.c: In function ‘__wine_ldr_start_proce
../../../wine-git/dlls/ntdll/loader.c:3861:5: error: too many arguments to
ion ‘virtual_set_large_address_space’
     virtual_set_large_address_space(force_large_address_aware);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../../../wine-git/dlls/ntdll/loader.c:45:
../../../wine-git/dlls/ntdll/ntdll_misc.h:196:13: note: declared here
 extern void virtual_set_large_address_space(void) DECLSPEC_HIDDEN;
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[1]: *** [Makefile:520: loader.o] Error 1
make[1]: Leaving directory '/home/user/PKGBUILDS-master/w
g-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntdll'
make: *** [Makefile:8465: dlls/ntdll] Error 2
make: *** Waiting for unfinished jobs....
../../../tools/winegcc/winegcc -s -o driver2.dll.so -B../../../tools/wineb
m64 \
  -fasynchronous-unwind-tables -nodefaultlibs -nostartfiles -Wl,--subsyste
ve -shared \
  ../../../../wine-git/dlls/ntoskrnl.exe/tests/driver2.spec driver2.o \
  ../../../dlls/winecrt0/libwinecrt0.a -lntoskrnl -Os
echo "ntdsapi_test.exe TESTRES \"ntdsapi_test-stripped.exe.so\"" | ../../.
s/wrc/wrc -o ../../../programs/winetest/ntdsapi_test.res
make[1]: Leaving directory '/home/user/PKGBUILDS-master/w
g-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntdsapi/t
../../../tools/winegcc/winegcc -o nvapi_test.exe.so -B../../../tools/wineb
m64 -fasynchronous-unwind-tables \
  nvapi.o testlist.o -luser32 -lshlwapi -ld3d9 -Os
../../../tools/winegcc/winegcc -s -o driver3.dll.so -B../../../tools/wineb
m64 \
  -fasynchronous-unwind-tables -nodefaultlibs -nostartfiles -Wl,--subsyste
ve -shared \
  ../../../../wine-git/dlls/ntoskrnl.exe/tests/driver3.spec driver3.o \
  ../../../dlls/winecrt0/libwinecrt0.a -lntoskrnl -Os
../../../tools/winegcc/winegcc -o ntprint_test.exe.so -B../../../tools/win
 -m64 -fasynchronous-unwind-tables \
  ntprint.o testlist.o -Os
make[1]: Leaving directory '/home/user/PKGBUILDS-master/w
g-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntoskrnl.
echo "msxml3_test.exe TESTRES \"msxml3_test-stripped.exe.so\"" | ../../../
wrc/wrc -o ../../../programs/winetest/msxml3_test.res
make[1]: Leaving directory '/home/user/PKGBUILDS-master/w
g-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/msxml3/te
echo "ntdll_test.exe TESTRES \"ntdll_test-stripped.exe.so\"" | ../../../to
c/wrc -o ../../../programs/winetest/ntdll_test.res
echo "nvapi_test.exe TESTRES \"nvapi_test-stripped.exe.so\"" | ../../../to
c/wrc -o ../../../programs/winetest/nvapi_test.res
make[1]: Leaving directory '/home/user/PKGBUILDS-master/w
g-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntdll/tes
echo "driver.dll TESTDLL \"driver.dll.so\"" | ../../../tools/wrc/wrc -o dr
es
echo "driver2.dll TESTDLL \"driver2.dll.so\"" | ../../../tools/wrc/wrc -o
2.res
echo "ntprint_test.exe TESTRES \"ntprint_test-stripped.exe.so\"" | ../../.
s/wrc/wrc -o ../../../programs/winetest/ntprint_test.res
make[1]: Leaving directory '/home/user/PKGBUILDS-master/w
g-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntprint/t
make[1]: Leaving directory '/home/user/PKGBUILDS-master/w
g-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/nvapi/tes
echo "driver3.dll TESTDLL \"driver3.dll.so\"" | ../../../tools/wrc/wrc -o
3.res
../../../tools/winegcc/winegcc -s -o ntoskrnl.exe_test-stripped.exe.so -B.
./tools/winebuild -m64 \
  -fasynchronous-unwind-tables -Wb,-F,ntoskrnl.exe_test.exe driver.res dri
es driver3.res \
  ntoskrnl.o testlist.o -ladvapi32 -Os
../../../tools/winegcc/winegcc -o ntoskrnl.exe_test.exe.so -B../../../tool
build -m64 -fasynchronous-unwind-tables \
  driver.res driver2.res driver3.res ntoskrnl.o testlist.o -ladvapi32 -Os
echo "ntoskrnl.exe_test.exe TESTRES \"ntoskrnl.exe_test-stripped.exe.so\""
../../tools/wrc/wrc -o ../../../programs/winetest/ntoskrnl.exe_test.res
make[1]: Leaving directory '/home/user/PKGBUILDS-master/w
g-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntoskrnl.
sts'
==> ERROR: A failure occurred in build().
    Aborting...
```


**3.18:**
 ```../../tools/winegcc/winegcc -o ntoskrnl.exe.fake -B../../tools/winebuild -m64 -fasynchronous-unwind-tables -shared ../../../wine-git/dlls/ntoskrnl.exe/ntoskrnl.exe.spec \
  instr.o ntoskrnl.o sync.o ntoskrnl.res -luser32 -ladvapi32 ../../libs/port/libwine_port.a \
  -Wb,-duser32 -Os
../../tools/winegcc/winegcc -o ntprint.dll.fake -B../../tools/winebuild -m64 -fasynchronous-unwind-tables -shared ../../../wine-git/dlls/ntprint/ntprint.spec
\
  ntprint.o ntprint.res -lwinspool ../../libs/port/libwine_port.a -Os
make[1]: Leaving directory '/home/user/PKGBUILDS-master/wine-tkg-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntprint'
make[1]: Entering directory '/home/user/PKGBUILDS-master/wine-tkg-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/nvapi/tests'
gcc -m64 -c -o nvapi.o ../../../../wine-git/dlls/nvapi/tests/nvapi.c -I. \
  -I../../../../wine-git/dlls/nvapi/tests -I../../../include -I../../../../wine-git/include \
  -D__WINESRC__ -D_REENTRANT -fPIC -Wall -pipe -fno-strict-aliasing -Wdeclaration-after-statement \
  -Wempty-body -Wignored-qualifiers -Wno-packed-not-aligned -Wshift-overflow=2
-Wstrict-prototypes \
  -Wtype-limits -Wunused-but-set-parameter -Wvla -Wwrite-strings -Wpointer-arith -Wlogical-op \
  -D_FORTIFY_SOURCE=2 -march=native -pipe -Os -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
gcc -m64 -c -o testlist.o testlist.c -I. -I../../../../wine-git/dlls/nvapi/tests -I../../../include \
  -I../../../../wine-git/include -D__WINESRC__ -D_REENTRANT -fPIC -Wall -pipe -fno-strict-aliasing \
  -Wdeclaration-after-statement -Wempty-body -Wignored-qualifiers -Wno-packed-not-aligned \
  -Wshift-overflow=2 -Wstrict-prototypes -Wtype-limits -Wunused-but-set-parameter -Wvla \
  -Wwrite-strings -Wpointer-arith -Wlogical-op -D_FORTIFY_SOURCE=2 -march=native -pipe -Os -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
../../../tools/winegcc/winegcc -s -o nvapi_test-stripped.exe.so -B../../../tools/winebuild -m64 \
  -fasynchronous-unwind-tables -Wb,-F,nvapi_test.exe nvapi.o testlist.o -luser32 -lshlwapi -ld3d9 \
  -Os
make[1]: Leaving directory '/home/user/PKGBUILDS-master/wine-tkg-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntdll'
make: *** [Makefile:8465: dlls/ntdll] Error 2
make: *** Waiting for unfinished jobs....
../../../tools/winegcc/winegcc -s -o driver3.dll.so -B../../../tools/winebuild
-m64 \
  -fasynchronous-unwind-tables -nodefaultlibs -nostartfiles -Wl,--subsystem,native -shared \
  ../../../../wine-git/dlls/ntoskrnl.exe/tests/driver3.spec driver3.o \
  ../../../dlls/winecrt0/libwinecrt0.a -lntoskrnl -Os
echo "ntprint_test.exe TESTRES \"ntprint_test-stripped.exe.so\"" | ../../../tools/wrc/wrc -o ../../../programs/winetest/ntprint_test.res
echo "ntdsapi_test.exe TESTRES \"ntdsapi_test-stripped.exe.so\"" | ../../../tools/wrc/wrc -o ../../../programs/winetest/ntdsapi_test.res
echo "driver.dll TESTDLL \"driver.dll.so\"" | ../../../tools/wrc/wrc -o driver.res
echo "driver2.dll TESTDLL \"driver2.dll.so\"" | ../../../tools/wrc/wrc -o driver2.res
echo "ntdll_test.exe TESTRES \"ntdll_test-stripped.exe.so\"" | ../../../tools/wrc/wrc -o ../../../programs/winetest/ntdll_test.res
make[1]: Leaving directory '/home/user/PKGBUILDS-master/wine-tkg-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntoskrnl.exe'
../../../tools/winegcc/winegcc -o nvapi_test.exe.so -B../../../tools/winebuild
-m64 -fasynchronous-unwind-tables \
  nvapi.o testlist.o -luser32 -lshlwapi -ld3d9 -Os
make[1]: Leaving directory '/home/user/PKGBUILDS-master/wine-tkg-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntdsapi/tests'
make[1]: Leaving directory '/home/user/PKGBUILDS-master/wine-tkg-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntdll/tests'
make[1]: Leaving directory '/home/user/PKGBUILDS-master/wine-tkg-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntprint/tests'
echo "nvapi_test.exe TESTRES \"nvapi_test-stripped.exe.so\"" | ../../../tools/wrc/wrc -o ../../../programs/winetest/nvapi_test.res
echo "driver3.dll TESTDLL \"driver3.dll.so\"" | ../../../tools/wrc/wrc -o driver3.res
../../../tools/winegcc/winegcc -s -o ntoskrnl.exe_test-stripped.exe.so -B../../../tools/winebuild -m64 \
  -fasynchronous-unwind-tables -Wb,-F,ntoskrnl.exe_test.exe driver.res driver2.res driver3.res \
  ntoskrnl.o testlist.o -ladvapi32 -Os
../../../tools/winegcc/winegcc -o ntoskrnl.exe_test.exe.so -B../../../tools/winebuild -m64 -fasynchronous-unwind-tables \
  driver.res driver2.res driver3.res ntoskrnl.o testlist.o -ladvapi32 -Os
make[1]: Leaving directory '/home/user/PKGBUILDS-master/wine-tkg-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/nvapi/tests'
echo "ntoskrnl.exe_test.exe TESTRES \"ntoskrnl.exe_test-stripped.exe.so\"" | ../../../tools/wrc/wrc -o ../../../programs/winetest/ntoskrnl.exe_test.res
make[1]: Leaving directory '/home/user/PKGBUILDS-master/wine-tkg-git/src/wine-tkg-staging-esync-pba-optimized-git-64-build/dlls/ntoskrnl.exe/tests'
==> ERROR: A failure occurred in build().
    Aborting... 