### PR TITLE
Mention using version tags where it's possible

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -63,7 +63,7 @@ _EXTERNAL_NOVER="false"
 
 #### WINE FLAVOUR SETTINGS ####
 
-# plain wine commit (short) if you want to use a specific wine version. Some versions: 3.16="64d9f30", 3.17="f11563c", 3.18="3f4455c", 3.19="d279bc2", 3.20="e9e12bd", 3.21="ea9253d".
+# plain wine commit (short) or version tag if you want to use a specific wine version. Can use e.g. "64d9f30", "wine-3.16" or "wine-4.0"
 # !!! Only affects non-staging builds (you want to edit the staging_version below for staging builds) !!!
 # Leave empty to use latest master - https://github.com/wine-mirror/wine/commits/master
 _plain_version=""
@@ -76,7 +76,7 @@ _esync_version=""
 
 # staging
 _use_staging="true"
-# staging commit (short) if you want to use a specific staging version. Some versions: 3.16="7cfceb7", 3.17="dc83f04", 3.18="30dca36", 3.19="5a85ab0", 3.20="a1b3847", 3.21="e6e67f2".
+# staging commit (short) or version tag if you want to use a specific staging version. Can use e.g. "7cfceb7", "v3.16" or "v4.0"
 # Leave empty to use latest master - https://github.com/wine-staging/wine-staging/commits/master
 _staging_version=""
 # You can optionally uncomment the _staging_args+=() option (and populate the bracket) to disable desired wine-staging patchsets.
@@ -95,7 +95,8 @@ _use_vkd3d="false"
 _use_dxvk="false"
 # use dxvk's own dxgi instead of wine's - This is helpful for some games (nvapi bypass anyone?) but breaks vkd3d compatibility
 _dxvk_dxgi="true"
-# dxvk commit (short) if you want to use a specific dxvk version. Leave empty to use latest master - https://github.com/doitsujin/dxvk/commits/master
+# dxvk commit (short) or version tag if you want to use a specific dxvk version. Can use e.g. "195fb582" or "v1.0.1"
+# Leave empty to use latest master - https://github.com/doitsujin/dxvk/commits/master
 _dxvk_version=""
 
 # legacy gallium nine - This is only available for 4.1-devel (prior to e24b162) and older wine versions


### PR DESCRIPTION
As `#tag=` is basically a glorified alias for `#commit=`, this is much easier than manually finding out the specific release commit beforehand.

(makepkg checks whether a tag is actually a valid tag if you use `#tag=`, which obviously won't happen here. Checkout will simply fail.)