### PR TITLE
linux50-tkg: Ask for menuconfig before building the kernel

### DIFF
--- a/linux50-tkg/PKGBUILD
+++ b/linux50-tkg/PKGBUILD
@@ -480,8 +480,19 @@ prepare() {
     make localmodconfig
   fi
 
-  # rewrite configuration
-  yes "" | make config >/dev/null
+  # menuconfig
+  if [ -z "$_menuconfig" ]; then
+    plain ""
+    plain "Do you want to use make menuconfig to configure the kernel before building it?"
+    read -p "`echo $'    > N/y : '`" CONDITION10;
+  fi
+  if [ "$CONDITION10" == "y" ] || [ "$_menuconfig" == "true" ]; then
+    make menuconfig
+  else
+    # rewrite configuration
+    yes "" | make config >/dev/null
+  fi
+
 }
 
 build() {

--- a/linux50-tkg/customization.cfg
+++ b/linux50-tkg/customization.cfg
@@ -17,6 +17,8 @@ _force_all_threads="false"
 # !!!! Make sure to have a well populated db !!!! - Leave empty to be asked about it at build time
 _modprobeddb=""
 
+# Set to true to call make menuconfig before building the kernel.
+_menuconfig=""
 
 #### KERNEL OPTIONS ####
 


### PR DESCRIPTION
Useful in case you need a specific module that is not in modprobed db.