### PR TITLE
Add 120Hz and 144Hz refresh rates

### DIFF
--- a/wine-tkg-git/wine-tkg-userpatches/valve_proton_144hz_fullscreen.mypatch
+++ b/wine-tkg-git/wine-tkg-userpatches/valve_proton_144hz_fullscreen.mypatch
@@ -1,0 +1,14 @@
+diff --git a/dlls/winex11.drv/settings.c b/dlls/winex11.drv/settings.c
+index 589c159b29..a03c3f6db8 100644
+--- a/dlls/winex11.drv/settings.c
++++ b/dlls/winex11.drv/settings.c
+@@ -378,6 +378,8 @@ void X11DRV_Settings_Init(void)
+                   fs_modes[i].h > fs_modes[0].h)))
+             continue;
+         X11DRV_Settings_AddOneMode( fs_modes[i].w, fs_modes[i].h, 0, 60);
++        X11DRV_Settings_AddOneMode( fs_modes[i].w, fs_modes[i].h, 0, 120);
++        X11DRV_Settings_AddOneMode( fs_modes[i].w, fs_modes[i].h, 0, 144);
+     }
+     X11DRV_Settings_AddDepthModes();
+ }
+

--- a/wine-tkg-git/wine-tkg-userpatches/virtual_desktop_144hz.mypatch
+++ b/wine-tkg-git/wine-tkg-userpatches/virtual_desktop_144hz.mypatch
@@ -1,0 +1,31 @@
+diff --git a/dlls/winex11.drv/desktop.c b/dlls/winex11.drv/desktop.c
+index d478cbdcb3..5042f96242 100644
+--- a/dlls/winex11.drv/desktop.c
++++ b/dlls/winex11.drv/desktop.c
+@@ -87,6 +87,8 @@ static void make_modes(void)
+ 
+     /* original specified desktop size */
+     X11DRV_Settings_AddOneMode(screen_width, screen_height, 0, 60);
++    X11DRV_Settings_AddOneMode(screen_width, screen_height, 0, 120);
++    X11DRV_Settings_AddOneMode(screen_width, screen_height, 0, 144);
+     for (i=0; i<ARRAY_SIZE(screen_sizes); i++)
+     {
+         if ( (screen_sizes[i].width <= max_width) && (screen_sizes[i].height <= max_height) )
+@@ -96,6 +98,8 @@ static void make_modes(void)
+             {
+                 /* only add them if they are smaller than the root window and unique */
+                 X11DRV_Settings_AddOneMode(screen_sizes[i].width, screen_sizes[i].height, 0, 60);
++                X11DRV_Settings_AddOneMode(screen_sizes[i].width, screen_sizes[i].height, 0, 120);
++                X11DRV_Settings_AddOneMode(screen_sizes[i].width, screen_sizes[i].height, 0, 144);
+             }
+         }
+     }
+@@ -103,6 +107,8 @@ static void make_modes(void)
+     {
+         /* root window size (if different from desktop window) */
+         X11DRV_Settings_AddOneMode(max_width, max_height, 0, 60);
++        X11DRV_Settings_AddOneMode(max_width, max_height, 0, 120);
++        X11DRV_Settings_AddOneMode(max_width, max_height, 0, 144);
+     }
+ }
+


### PR DESCRIPTION
This patch adds 120 and 144HZ refresh rates because
Proton fullscreen patches only support 60Hz for fullscreen
The same applies to the wine virtual desktop which only
supports 60Hz and causes many games to have bad micro
stutters if the framerate exceeds the artifical 60Hz
while running with e.g. 144Hz natively.
With this patch freesync and 144Hz runs butter smooth
for displays that support it.