### PR TITLE
Correct license

### DIFF
--- a/faudio-git/PKGBUILD
+++ b/faudio-git/PKGBUILD
@@ -38,7 +38,7 @@ pkgrel=1
 pkgdesc="Accuracy-focused XAudio reimplementation for open platforms"
 arch=('i686' 'x86_64')
 url='https://github.com/FNA-XNA/FAudio'
-license=('custom')
+license=('Zlib')
 depends=('sdl2' 'ffmpeg')
 
 # lib32


### PR DESCRIPTION
The license was changed on the Feb 20, 2018 to Zlib - https://github.com/FNA-XNA/FAudio/commit/6c679d121fd421a22ae87315ae5753bdb18db975