### PR TITLE
Minor default `user_settings.py` improvements

### DIFF
--- a/proton-tkg/proton_template/conf/user_settings.py
+++ b/proton-tkg/proton_template/conf/user_settings.py
@@ -40,11 +40,11 @@ user_settings = {
     #Enable Winetricks prompt on game launch
 #    "PROTON_WINETRICKS": "1",
 
-    #Use OpenGL-based wined3d for d3d9/d3d10/d3d11 instead of vulkan-based DXVK & D9VK !!! Won't affect winelib builds !!!
+    #Use OpenGL-based wined3d for d3d11/d3d10/d3d9 instead of vulkan-based DXVK & D9VK !!! Won't affect winelib builds !!!
 #    "PROTON_USE_WINED3D": "1",
 
-    #Use OpenGL-based wined3d for d3d10/11 only (keeping D9VK enabled). Comment out to use vulkan-based DXVK instead.
-    #!!! DXVK winelib replaces wined3d d3d10/d3d11 and needs this option enabled !!!
+    #Use OpenGL-based wined3d for d3d11/10 only (keeping D9VK enabled). Comment out to use vulkan-based DXVK instead.
+    #!!! DXVK winelib replaces wined3d d3d11/d3d10 and needs this option enabled !!!
 #    "PROTON_USE_WINED3D11": "1",
 
     #Enable custom d3d9 dll usage. This is the option you want to enable to use Gallium 9. Builtin D9VK won't be used with this option enabled.

--- a/proton-tkg/proton_template/conf/user_settings.py
+++ b/proton-tkg/proton_template/conf/user_settings.py
@@ -50,7 +50,7 @@ user_settings = {
     #Enable custom d3d9 dll usage. This is the option you want to enable to use Gallium 9. Builtin D9VK won't be used with this option enabled.
 #    "PROTON_USE_CUSTOMD3D9": "1",
 
-    #Use OpenGL-based wined3d for d3d9 only (keeping DXVK enabled). Comment out to use vulkan-based D9VK or custom d3d9 dll instead.
+    #Use OpenGL-based wined3d for d3d9 only (keeping DXVK enabled). Comment out to use Vulkan-based D9VK or custom d3d9 dll instead.
     #!!! D9VK winelib replaces wined3d d3d9 and needs this option enabled !!!
     "PROTON_USE_WINED3D9": "1",
 

--- a/proton-tkg/proton_template/conf/user_settings.py
+++ b/proton-tkg/proton_template/conf/user_settings.py
@@ -40,7 +40,7 @@ user_settings = {
     #Enable Winetricks prompt on game launch
 #    "PROTON_WINETRICKS": "1",
 
-    #Use OpenGL-based wined3d for d3d11/d3d10/d3d9 instead of vulkan-based DXVK & D9VK !!! Won't affect winelib builds !!!
+    #Use OpenGL-based wined3d for d3d11/d3d10/d3d9 instead of Vulkan-based DXVK & D9VK !!! Won't affect winelib builds !!!
 #    "PROTON_USE_WINED3D": "1",
 
     #Use OpenGL-based wined3d for d3d11/10 only (keeping D9VK enabled). Comment out to use vulkan-based DXVK instead.

--- a/proton-tkg/proton_template/conf/user_settings.py
+++ b/proton-tkg/proton_template/conf/user_settings.py
@@ -1,18 +1,16 @@
-#to enable these settings, name this file "user_settings.py"
-
 #Settings here will take effect for all games run in this Proton version.
 
 user_settings = {
     #Logs are saved to $HOME/steam-<STEAM_GAME_ID>.log, overwriting any previous log with that name.
 
-    #Wine debug logging - default="+timestamp,+pid,+tid,+seh,+debugstr,+loaddll,+mscoree"
-#     "WINEDEBUG": "",
+    #Wine debug logging
+#     "WINEDEBUG": "+timestamp,+pid,+tid,+seh,+debugstr,+loaddll,+mscoree",
 
     #DXVK debug logging
 #     "DXVK_LOG_LEVEL": "info",
 
     #wine-mono debug logging (Wine's .NET replacement)
-     "WINE_MONO_TRACE": "E:System.NotImplementedException",
+#     "WINE_MONO_TRACE": "E:System.NotImplementedException",
 #     "MONO_LOG_LEVEL": "info",
 
     #Set DXVK custom config path
@@ -45,14 +43,14 @@ user_settings = {
     #Use OpenGL-based wined3d for d3d9/d3d10/d3d11 instead of vulkan-based DXVK & D9VK !!! Won't affect winelib builds !!!
 #     "PROTON_USE_WINED3D": "1",
 
-    #Use gl-based wined3d for d3d10/11 only (keeping D9VK enabled). Comment out to use vulkan-based DXVK instead.
+    #Use OpenGL-based wined3d for d3d10/11 only (keeping D9VK enabled). Comment out to use vulkan-based DXVK instead.
     #!!! DXVK winelib replaces wined3d d3d10/d3d11 and needs this option enabled !!!
 #     "PROTON_USE_WINED3D11": "1",
 
     #Enable custom d3d9 dll usage. This is the option you want to enable to use Gallium 9. Builtin D9VK won't be used with this option enabled.
 #     "PROTON_USE_CUSTOMD3D9": "1",
 
-    #Use gl-based wined3d for d3d9 only (keeping DXVK enabled). Comment out to use vulkan-based D9VK or custom d3d9 dll instead.
+    #Use OpenGL-based wined3d for d3d9 only (keeping DXVK enabled). Comment out to use vulkan-based D9VK or custom d3d9 dll instead.
     #!!! D9VK winelib replaces wined3d d3d9 and needs this option enabled !!!
      "PROTON_USE_WINED3D9": "1",
 

--- a/proton-tkg/proton_template/conf/user_settings.py
+++ b/proton-tkg/proton_template/conf/user_settings.py
@@ -4,68 +4,68 @@ user_settings = {
     #Logs are saved to $HOME/steam-<STEAM_GAME_ID>.log, overwriting any previous log with that name.
 
     #Wine debug logging
-#     "WINEDEBUG": "+timestamp,+pid,+tid,+seh,+debugstr,+loaddll,+mscoree",
+#    "WINEDEBUG": "+timestamp,+pid,+tid,+seh,+debugstr,+loaddll,+mscoree",
 
     #DXVK debug logging
-#     "DXVK_LOG_LEVEL": "info",
+#    "DXVK_LOG_LEVEL": "info",
 
     #wine-mono debug logging (Wine's .NET replacement)
-#     "WINE_MONO_TRACE": "E:System.NotImplementedException",
-#     "MONO_LOG_LEVEL": "info",
+#    "WINE_MONO_TRACE": "E:System.NotImplementedException",
+#    "MONO_LOG_LEVEL": "info",
 
     #Set DXVK custom config path
-#     "DXVK_CONFIG_FILE": "",
+#    "DXVK_CONFIG_FILE": "",
 
     #Enable DXVK Async pipecompiler
-#     "PROTON_DXVK_ASYNC": "1",
+#    "PROTON_DXVK_ASYNC": "1",
 
     #Enable DXVK's HUD
-#     "DXVK_HUD": "devinfo,fps",
+#    "DXVK_HUD": "devinfo,fps",
 
     #Write the command proton sends to wine for targeted prefix (/prefix/path/launch_command) - Helpful to track bound executable
-     "PROTON_LOG_COMMAND_TO_PREFIX": "1",
+    "PROTON_LOG_COMMAND_TO_PREFIX": "1",
 
     #Disable nvapi and nvapi64
-     "PROTON_NVAPI_DISABLE": "1",
+    "PROTON_NVAPI_DISABLE": "1",
 
     #Disable winedbg
-     "PROTON_WINEDBG_DISABLE": "1",
+    "PROTON_WINEDBG_DISABLE": "1",
 
     #Enable IMAGE_FILE_LARGE_ADDRESS_AWARE override - Required by some 32-bit games hitting address space issues
-#     "PROTON_FORCE_LARGE_ADDRESS_AWARE": "1",
+#    "PROTON_FORCE_LARGE_ADDRESS_AWARE": "1",
 
     #Reduce Pulse Latency
-     "PROTON_PULSE_LOWLATENCY": "1",
+    "PROTON_PULSE_LOWLATENCY": "1",
 
     #Enable Winetricks prompt on game launch
-#     "PROTON_WINETRICKS": "1",
+#    "PROTON_WINETRICKS": "1",
 
     #Use OpenGL-based wined3d for d3d9/d3d10/d3d11 instead of vulkan-based DXVK & D9VK !!! Won't affect winelib builds !!!
-#     "PROTON_USE_WINED3D": "1",
+#    "PROTON_USE_WINED3D": "1",
 
     #Use OpenGL-based wined3d for d3d10/11 only (keeping D9VK enabled). Comment out to use vulkan-based DXVK instead.
     #!!! DXVK winelib replaces wined3d d3d10/d3d11 and needs this option enabled !!!
-#     "PROTON_USE_WINED3D11": "1",
+#    "PROTON_USE_WINED3D11": "1",
 
     #Enable custom d3d9 dll usage. This is the option you want to enable to use Gallium 9. Builtin D9VK won't be used with this option enabled.
-#     "PROTON_USE_CUSTOMD3D9": "1",
+#    "PROTON_USE_CUSTOMD3D9": "1",
 
     #Use OpenGL-based wined3d for d3d9 only (keeping DXVK enabled). Comment out to use vulkan-based D9VK or custom d3d9 dll instead.
     #!!! D9VK winelib replaces wined3d d3d9 and needs this option enabled !!!
-     "PROTON_USE_WINED3D9": "1",
+    "PROTON_USE_WINED3D9": "1",
 
     #Use wine DXGI instead of DXVK's. This is needed to make use of VKD3D when DXVK is enabled. It will prevent the use of DXVK's DXGI functions.
-#     "PROTON_USE_WINE_DXGI": "1",
+#    "PROTON_USE_WINE_DXGI": "1",
 
     #Disable d3d11 entirely !!!
-#     "PROTON_NO_D3D11": "1",
+#    "PROTON_NO_D3D11": "1",
 
     #Disable d3d10 entirely !!!
-#     "PROTON_NO_D3D10": "1",
+#    "PROTON_NO_D3D10": "1",
 
     #Disable d3d9 entirely !!!
-#     "PROTON_NO_D3D9": "1",
+#    "PROTON_NO_D3D9": "1",
 
     #Disable in-process synchronization primitives
-#     "PROTON_NO_ESYNC": "1",
+#    "PROTON_NO_ESYNC": "1",
 }


### PR DESCRIPTION
* Removed mention about renaming – compared to regular proton, proton-tkg already ships the file renamed and enabled by default.
* Made `WINE_MONO_TRACE` commented out by default like the others.
* Moved default `WINEDEBUG` options to variable like the others (it's commented by default anyway).
* Renamed gl-based -> OpenGL-based like the others.

Side effect is making the comments a bit more up to date with the Valve's `user_settings.sample.py`. :)