### PR TITLE
Add compiler flag options for cross-compilation

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -1330,11 +1330,14 @@ build() {
 	# compiler flags
 	if [ "$_LOCAL_OPTIMIZED" == "true" ]; then
 	  export CFLAGS="${_GCC_FLAGS}"
-	  export CXXFLAGS="${_GCC_FLAGS}"
 	  export LDFLAGS="${_LD_FLAGS}"
+	  export CROSSCFLAGS="${_CROSS_FLAGS}"
+	  export CROSSLDFLAGS="${_CROSS_LD_FLAGS}"
 	  echo "With predefined optimizations:" >> "$_where"/last_build_config.log
-	  echo "CFLAGS = ${_GCC_FLAGS}" >> "$_where"/last_build_config.log
-	  echo "LDFLAGS = ${_LD_FLAGS}" >> "$_where"/last_build_config.log
+	  echo "CFLAGS = ${CFLAGS}" >> "$_where"/last_build_config.log
+	  echo "LDFLAGS = ${LDFLAGS}" >> "$_where"/last_build_config.log
+	  echo "CROSSCFLAGS = ${CROSSCFLAGS}" >> "$_where"/last_build_config.log
+	  echo "CROSSLDFLAGS = ${CROSSLDFLAGS}" >> "$_where"/last_build_config.log
 	else
 	  echo "Using /etc/makepkg.conf settings for compiler optimization flags" >> "$_where"/last_build_config.log
 	fi
@@ -1345,6 +1348,8 @@ build() {
 	if [ -z "$_proton_tkg_path" ]; then
 	  export CFLAGS="${CFLAGS/-fno-plt/}"
 	  export LDFLAGS="${LDFLAGS/,-z,now/}"
+	  export CROSSCFLAGS="${CROSSCFLAGS/-fno-plt/}"
+	  export CROSSLDFLAGS="${CROSSLDFLAGS/,-z,now/}"
 	fi
 
 	local _prefix=/usr

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -18,6 +18,10 @@ _LOCAL_OPTIMIZED="true"
 _GCC_FLAGS="-pipe -O2 -ftree-vectorize"
 # Custom LD flags to use instead of system-wide makepkg flags set in /etc/makepkg.conf. Default is "-pipe -O2 -ftree-vectorize".
 _LD_FLAGS="-pipe -O2 -ftree-vectorize"
+# Same as _GCC_FLAGS but for cross-compiled binaries.
+_CROSS_FLAGS="-pipe -O2 -ftree-vectorize"
+# Same as _LD_FLAGS but for cross-compiled binaries.
+_CROSS_LD_FLAGS="-pipe -O2 -ftree-vectorize"
 
 # By default, tests are disabled to speed up compilation. If you need them for development purposes, set to "true"
 _ENABLE_TESTS="false"

--- a/wine-tkg-git/wine-tkg-profiles/wine-tkg-mainline.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/wine-tkg-mainline.cfg
@@ -7,6 +7,8 @@
 _LOCAL_OPTIMIZED="false"
 #_GCC_FLAGS="-pipe -O2 -ftree-vectorize -march=native"
 #_LD_FLAGS="-pipe -O2 -ftree-vectorize"
+#_CROSS_FLAGS="-pipe -O2 -ftree-vectorize -march=native"
+#_CROSS_LD_FLAGS="-pipe -O2 -ftree-vectorize"
 _ENABLE_TESTS="false"
 _NUKR="true"
 _NOLIB32="false"

--- a/wine-tkg-git/wine-tkg-profiles/wine-tkg-staging.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/wine-tkg-staging.cfg
@@ -7,6 +7,8 @@
 _LOCAL_OPTIMIZED="false"
 #_GCC_FLAGS="-pipe -O2 -ftree-vectorize -march=native"
 #_LD_FLAGS="-pipe -O2 -ftree-vectorize"
+#_CROSS_FLAGS="-pipe -O2 -ftree-vectorize -march=native"
+#_CROSS_LD_FLAGS="-pipe -O2 -ftree-vectorize"
 _ENABLE_TESTS="false"
 _NUKR="true"
 _NOLIB32="false"

--- a/wine-tkg-git/wine-tkg-profiles/wine-tkg.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/wine-tkg.cfg
@@ -7,6 +7,8 @@
 _LOCAL_OPTIMIZED="true"
 _GCC_FLAGS="-pipe -O2 -ftree-vectorize -march=native"
 _LD_FLAGS="-pipe -O2 -ftree-vectorize"
+_CROSS_FLAGS="-pipe -O2 -ftree-vectorize -march=native"
+_CROSS_LD_FLAGS="-pipe -O2 -ftree-vectorize"
 _ENABLE_TESTS="false"
 _NUKR="true"
 _NOLIB32="false"


### PR DESCRIPTION
I don't think C++ or Objective-C are used anywhere, but it can't hurt to have the options right?