### PR TITLE
mingw-w64-cmake is needed to build mingw-w64-sdl2

### DIFF
--- a/mingw/mingw-on-arch-automator.sh
+++ b/mingw/mingw-on-arch-automator.sh
@@ -181,8 +181,8 @@ _AURPKGNAME=mingw-w64-gcc
 _mingwloop
 
 if [ $_sdlandco == "true" ]; then
-  # mingw-w64-pkg-config - mingw-w64-configure - mingw-w64-sdl2
-  _AURPKGS=(mingw-w64-pkg-config mingw-w64-configure mingw-w64-sdl2)
+  # mingw-w64-pkg-config - mingw-w64-configure - mingw-w64-cmake - mingw-w64-sdl2
+  _AURPKGS=(mingw-w64-pkg-config mingw-w64-configure mingw-w64-cmake mingw-w64-sdl2)
   for _AURPKGNAME in "${_AURPKGS[@]}"; do
     _mingwloop
   done


### PR DESCRIPTION
Mentioned it on Discord yesterday; it seems mingw-w64-cmake is needed for mingw-w64-sdl2. Adding that to my local script made mingw-w64-sdl2 build successfully for me.