### PR TITLE
typo: merge -> merged

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -75,7 +75,7 @@ _plain_mirrorsrc="true"
 # You can optionally uncomment the _configure_userargs="" option below to set custom configure-args, separated by a space (example: "--without-mingw --with-vkd3d")
 #_configure_userargs=""
 
-# esync - Enable with WINEESYNC=1 envvar - Set to true to enable esync support on plain wine or wine-staging <4.6 (it got merge in wine-staging 4.6). The option is ignored on wine-staging 4.6+
+# esync - Enable with WINEESYNC=1 envvar - Set to true to enable esync support on plain wine or wine-staging <4.6 (it got merged in wine-staging 4.6). The option is ignored on wine-staging 4.6+
 # You may need to raise your fd limits -> https://github.com/zfigura/wine/blob/esync/README.esync
 _use_esync="true"
 # fsync - Enable with WINEFSYNC=1 envvar - Set to true to enable fsync support, an experimental replacement for esync introduced with Proton 4.11-1 - Requires Wine Mainline 4.7.r168.g29914d583f / Staging 4.9.r7.g197e08b4 or newer


### PR DESCRIPTION
Fixing comment added in eb3cd9ea2c6a533e7a15ffa5fe752754c21a2d7c, blame my OCD :frog: