### PR TITLE
wine-tkg-git: Fix 'Maximum modes exceeded' errors caused by refresh rate patch

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/proton_FS_hack_refreshrate.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/proton_FS_hack_refreshrate.patch
@@ -2,6 +2,17 @@ diff --git a/dlls/winex11.drv/settings.c b/dlls/winex11.drv/settings.c
 index 589c159b29..a03c3f6db8 100644
 --- a/dlls/winex11.drv/settings.c
 +++ b/dlls/winex11.drv/settings.c
+@@ -65,8 +65,8 @@ struct x11drv_mode_info *X11DRV_Settings_SetHandlers(const char *name,
+     pSetCurrentMode = pNewSCM;
+     TRACE("Resolution settings now handled by: %s\n", name);
+     if (reserve_depths)
+-        /* leave room for other depths */
+-        dd_max_modes = (3+1)*(nmodes);
++        /* leave room for other depths and refresh rates */
++        dd_max_modes = 2*(3+1)*(nmodes);
+     else 
+         dd_max_modes = nmodes;
+ 
 @@ -378,6 +378,7 @@ void X11DRV_Settings_Init(void)
                    fs_modes[i].h > fs_modes[0].h)))
              continue;


### PR DESCRIPTION
Currently the fake refresh rate option causes this error to be spammed whenever you run wine:

`0043:err:x11settings:X11DRV_Settings_AddOneMode Maximum modes (88) exceeded`

The extra modes still seem to appear in game though. The fix is to copy the realmodes patch and double the maximum modes available.