### PR TITLE
linux-tkg:  add patch for umip instruction emulation

### DIFF
--- a/linux419-tkg/PKGBUILD
+++ b/linux419-tkg/PKGBUILD
@@ -78,7 +78,7 @@ pkgname=("${pkgbase}" "${pkgbase}-headers")
 _basekernel=4.19
 _sub=73
 pkgver="${_basekernel}"."${_sub}"
-pkgrel=102
+pkgrel=103
 arch=('x86_64') # no i686 in here
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -112,6 +112,7 @@ source=("https://www.kernel.org/pub/linux/kernel/v4.x/linux-${_basekernel}.tar.x
         0008-uksm.patch
         0009-linux-hardened.patch
         0010-drm-amd-powerplay-force-the-trim-of-the-mclk-dpm-levels-if-OD-is-enabled.patch
+        0011-umip-instruction-emulation.patch
 )
 sha256sums=('0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1'
             'b1d43219a90be452e3ede4de002073269ce7e1269832e48a5abaaae99ccb6b81'
@@ -132,7 +133,8 @@ sha256sums=('0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1'
             'b1ab517fbd0a085ca1cd2e20271bb2665729b10772a463b7b252e1679f8da6cb'
             'b58555e0a1dc18a75db0a436e446374bd0c2c45a3e39c86282a006f0862c546a'
             'babe6aaaab7df5aac831dec886674dcdf83877d031fb629c8ffadc0f20b0d3e9'
-            '8296024e664a4957c0f79940cf4842c70f7d82b40b5fdccdfe055e62f9d58d40')
+            '8296024e664a4957c0f79940cf4842c70f7d82b40b5fdccdfe055e62f9d58d40'
+            'a96fb714db831f0848d1ed4245f9c7bf5c83afb4d25174b06c38b7fdff3b4dbc')
 
 user_patcher() {
 	# To patch the user because all your base are belong to us
@@ -663,6 +665,17 @@ prepare() {
     echo "# CONFIG_BCACHEFS_DEBUG is not set" >> ./.config
     echo "# CONFIG_BCACHEFS_TESTS is not set" >> ./.config
     echo "# CONFIG_DEBUG_CLOSURES is not set" >> ./.config
+  fi
+
+  # umip emulation support
+  if [ -z "$_umip_instruction_emulation" ]; then
+    plain ""
+    plain "Enable support for emulation of the SGDT, SIDT, and SMSW instructions for 64-bit processes?"
+    plain "May help with crashing in certain 64-bit Windows games under Wine, on UMIP-enabled systems."
+    read -rp "`echo $'    > N/y : '`" CONDITION11;
+  fi
+  if [ "$CONDITION11" == "y" ] || [ "$_umip_instruction_emulation" == "true" ]; then
+    patch -Np1 -i ../0011-umip-instruction-emulation.patch
   fi
 
   # userpatches

--- a/linux419-tkg/customization.cfg
+++ b/linux419-tkg/customization.cfg
@@ -94,6 +94,9 @@ _bcachefs=""
 # A selection of patches from Zen/Liquorix kernel and additional tweaks for a better gaming experience (ZENIFY) - Default is "true"
 _zenify="true"
 
+# Set to true to enable emulation of the SGDT, SIDT, and SMSW instructions for 64-bit processes. May help with crashing in certain 64-bit Windows games under Wine, on UMIP-enabled systems.
+_umip_instruction_emulation=""
+
 # compiler optimization level - 1. Optimize for performance (-O2); 2. Optimize harder (-O3); 3. Optimize for size (-Os) - Kernel default is "2"
 _compileroptlevel="2"
 

--- a/linux419-tkg/linux419-tkg-patches/0011-umip-instruction-emulation.patch
+++ b/linux419-tkg/linux419-tkg-patches/0011-umip-instruction-emulation.patch
@@ -1,0 +1,194 @@
+From e86c2c8b9380440bbe761b8e2f63ab6b04a45ac2 Mon Sep 17 00:00:00 2001
+From: Brendan Shanks <bshanks@codeweavers.com>
+Date: Thu, 5 Sep 2019 16:22:21 -0700
+Subject: x86/umip: Add emulation (spoofing) for UMIP covered instructions in
+ 64-bit processes as well
+
+Add emulation (spoofing) of the SGDT, SIDT, and SMSW instructions for 64-bit
+processes.
+
+Wine users have encountered a number of 64-bit Windows games that use
+these instructions (particularly SGDT), and were crashing when run on
+UMIP-enabled systems.
+
+Originally-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
+Signed-off-by: Brendan Shanks <bshanks@codeweavers.com>
+Reviewed-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
+Reviewed-by: H. Peter Anvin (Intel) <hpa@zytor.com>
+Cc: Andy Lutomirski <luto@kernel.org>
+Cc: Borislav Petkov <bp@alien8.de>
+Cc: Brian Gerst <brgerst@gmail.com>
+Cc: Denys Vlasenko <dvlasenk@redhat.com>
+Cc: Eric W. Biederman <ebiederm@xmission.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Link: https://lkml.kernel.org/r/20190905232222.14900-1-bshanks@codeweavers.com
+[ Minor edits: capitalization, added 'spoofing' wording. ]
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+---
+ arch/x86/kernel/umip.c | 65 +++++++++++++++++++++++++++++---------------------
+ 1 file changed, 38 insertions(+), 27 deletions(-)
+
+diff --git a/arch/x86/kernel/umip.c b/arch/x86/kernel/umip.c
+index 5b345add550f..548fefed71ee 100644
+--- a/arch/x86/kernel/umip.c
++++ b/arch/x86/kernel/umip.c
+@@ -19,7 +19,7 @@
+ /** DOC: Emulation for User-Mode Instruction Prevention (UMIP)
+  *
+  * The feature User-Mode Instruction Prevention present in recent Intel
+- * processor prevents a group of instructions (sgdt, sidt, sldt, smsw, and str)
++ * processor prevents a group of instructions (SGDT, SIDT, SLDT, SMSW and STR)
+  * from being executed with CPL > 0. Otherwise, a general protection fault is
+  * issued.
+  *
+@@ -36,8 +36,8 @@
+  * DOSEMU2) rely on this subset of instructions to function.
+  *
+  * The instructions protected by UMIP can be split in two groups. Those which
+- * return a kernel memory address (sgdt and sidt) and those which return a
+- * value (sldt, str and smsw).
++ * return a kernel memory address (SGDT and SIDT) and those which return a
++ * value (SLDT, STR and SMSW).
+  *
+  * For the instructions that return a kernel memory address, applications
+  * such as WineHQ rely on the result being located in the kernel memory space,
+@@ -45,15 +45,13 @@
+  * value that, lies close to the top of the kernel memory. The limit for the GDT
+  * and the IDT are set to zero.
+  *
+- * Given that sldt and str are not commonly used in programs that run on WineHQ
++ * Given that SLDT and STR are not commonly used in programs that run on WineHQ
+  * or DOSEMU2, they are not emulated.
+  *
+  * The instruction smsw is emulated to return the value that the register CR0
+  * has at boot time as set in the head_32.
+  *
+- * Also, emulation is provided only for 32-bit processes; 64-bit processes
+- * that attempt to use the instructions that UMIP protects will receive the
+- * SIGSEGV signal issued as a consequence of the general protection fault.
++ * Emulation is provided for both 32-bit and 64-bit processes.
+  *
+  * Care is taken to appropriately emulate the results when segmentation is
+  * used. That is, rather than relying on USER_DS and USER_CS, the function
+@@ -63,17 +61,18 @@
+  * application uses a local descriptor table.
+  */
+ 
+-#define UMIP_DUMMY_GDT_BASE 0xfffe0000
+-#define UMIP_DUMMY_IDT_BASE 0xffff0000
++#define UMIP_DUMMY_GDT_BASE 0xfffffffffffe0000ULL
++#define UMIP_DUMMY_IDT_BASE 0xffffffffffff0000ULL
+ 
+ /*
+  * The SGDT and SIDT instructions store the contents of the global descriptor
+  * table and interrupt table registers, respectively. The destination is a
+  * memory operand of X+2 bytes. X bytes are used to store the base address of
+- * the table and 2 bytes are used to store the limit. In 32-bit processes, the
+- * only processes for which emulation is provided, X has a value of 4.
++ * the table and 2 bytes are used to store the limit. In 32-bit processes X
++ * has a value of 4, in 64-bit processes X has a value of 8.
+  */
+-#define UMIP_GDT_IDT_BASE_SIZE 4
++#define UMIP_GDT_IDT_BASE_SIZE_64BIT 8
++#define UMIP_GDT_IDT_BASE_SIZE_32BIT 4
+ #define UMIP_GDT_IDT_LIMIT_SIZE 2
+ 
+ #define	UMIP_INST_SGDT	0	/* 0F 01 /0 */
+@@ -189,6 +188,7 @@ static int identify_insn(struct insn *insn)
+  * @umip_inst:	A constant indicating the instruction to emulate
+  * @data:	Buffer into which the dummy result is stored
+  * @data_size:	Size of the emulated result
++ * @x86_64:	true if process is 64-bit, false otherwise
+  *
+  * Emulate an instruction protected by UMIP and provide a dummy result. The
+  * result of the emulation is saved in @data. The size of the results depends
+@@ -202,11 +202,8 @@ static int identify_insn(struct insn *insn)
+  * 0 on success, -EINVAL on error while emulating.
+  */
+ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+-			     unsigned char *data, int *data_size)
++			     unsigned char *data, int *data_size, bool x86_64)
+ {
+-	unsigned long dummy_base_addr, dummy_value;
+-	unsigned short dummy_limit = 0;
+-
+ 	if (!data || !data_size || !insn)
+ 		return -EINVAL;
+ 	/*
+@@ -219,6 +216,9 @@ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+ 	 * is always returned irrespective of the operand size.
+ 	 */
+ 	if (umip_inst == UMIP_INST_SGDT || umip_inst == UMIP_INST_SIDT) {
++		u64 dummy_base_addr;
++		u16 dummy_limit = 0;
++
+ 		/* SGDT and SIDT do not use registers operands. */
+ 		if (X86_MODRM_MOD(insn->modrm.value) == 3)
+ 			return -EINVAL;
+@@ -228,13 +228,24 @@ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+ 		else
+ 			dummy_base_addr = UMIP_DUMMY_IDT_BASE;
+ 
+-		*data_size = UMIP_GDT_IDT_LIMIT_SIZE + UMIP_GDT_IDT_BASE_SIZE;
++		/*
++		 * 64-bit processes use the entire dummy base address.
++		 * 32-bit processes use the lower 32 bits of the base address.
++		 * dummy_base_addr is always 64 bits, but we memcpy the correct
++		 * number of bytes from it to the destination.
++		 */
++		if (x86_64)
++			*data_size = UMIP_GDT_IDT_BASE_SIZE_64BIT;
++		else
++			*data_size = UMIP_GDT_IDT_BASE_SIZE_32BIT;
++
++		memcpy(data + 2, &dummy_base_addr, *data_size);
+ 
+-		memcpy(data + 2, &dummy_base_addr, UMIP_GDT_IDT_BASE_SIZE);
++		*data_size += UMIP_GDT_IDT_LIMIT_SIZE;
+ 		memcpy(data, &dummy_limit, UMIP_GDT_IDT_LIMIT_SIZE);
+ 
+ 	} else if (umip_inst == UMIP_INST_SMSW) {
+-		dummy_value = CR0_STATE;
++		unsigned long dummy_value = CR0_STATE;
+ 
+ 		/*
+ 		 * Even though the CR0 register has 4 bytes, the number
+@@ -290,11 +301,10 @@ static void force_sig_info_umip_fault(void __user *addr, struct pt_regs *regs)
+  * fixup_umip_exception() - Fixup a general protection fault caused by UMIP
+  * @regs:	Registers as saved when entering the #GP handler
+  *
+- * The instructions sgdt, sidt, str, smsw, sldt cause a general protection
+- * fault if executed with CPL > 0 (i.e., from user space). If the offending
+- * user-space process is not in long mode, this function fixes the exception
+- * up and provides dummy results for sgdt, sidt and smsw; str and sldt are not
+- * fixed up. Also long mode user-space processes are not fixed up.
++ * The instructions SGDT, SIDT, STR, SMSW and SLDT cause a general protection
++ * fault if executed with CPL > 0 (i.e., from user space). This function fixes
++ * the exception up and provides dummy results for SGDT, SIDT and SMSW; STR
++ * and SLDT are not fixed up.
+  *
+  * If operands are memory addresses, results are copied to user-space memory as
+  * indicated by the instruction pointed by eIP using the registers indicated in
+@@ -373,13 +383,14 @@ bool fixup_umip_exception(struct pt_regs *regs)
+ 	umip_pr_warning(regs, "%s instruction cannot be used by applications.\n",
+ 			umip_insns[umip_inst]);
+ 
+-	/* Do not emulate SLDT, STR or user long mode processes. */
+-	if (umip_inst == UMIP_INST_STR || umip_inst == UMIP_INST_SLDT || user_64bit_mode(regs))
++	/* Do not emulate (spoof) SLDT or STR. */
++	if (umip_inst == UMIP_INST_STR || umip_inst == UMIP_INST_SLDT)
+ 		return false;
+ 
+ 	umip_pr_warning(regs, "For now, expensive software emulation returns the result.\n");
+ 
+-	if (emulate_umip_insn(&insn, umip_inst, dummy_data, &dummy_data_size))
++	if (emulate_umip_insn(&insn, umip_inst, dummy_data, &dummy_data_size,
++			      user_64bit_mode(regs)))
+ 		return false;
+ 
+ 	/*
+-- 
+cgit 1.2-0.3.lf.el7
+

--- a/linux51-tkg/PKGBUILD
+++ b/linux51-tkg/PKGBUILD
@@ -84,7 +84,7 @@ pkgname=("${pkgbase}" "${pkgbase}-headers")
 _basekernel=5.1
 _sub=21
 pkgver="${_basekernel}"."${_sub}"
-pkgrel=36
+pkgrel=37
 arch=('x86_64') # no i686 in here
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -120,6 +120,7 @@ source=("https://www.kernel.org/pub/linux/kernel/v5.x/linux-${_basekernel}.tar.x
         0010-v5.1_bmq096.patch
         0011-ZFS-fix.patch
         0012-linux-hardened.patch
+        0013-umip-instruction-emulation.patch
 )
 sha256sums=('d06a7be6e73f97d1350677ad3bae0ce7daecb79c2c2902aaabe806f7fa94f041'
             '1283bb5ef11e8a137c6df22fcc4ab6535a20bef11f70057248c6b0fc2683203b'
@@ -142,7 +143,8 @@ sha256sums=('d06a7be6e73f97d1350677ad3bae0ce7daecb79c2c2902aaabe806f7fa94f041'
             '2597aabe1d3d4d1b94ce37b4c9e7e73c45804b4ca33976ba9c5c895ea0bb6be4'
             '48be5e7f27d4a0570bd31f37ed1ad35241ff7f427dae5513cab875c7b44aeb08'
             'dc4f939085d2dc6e6ebdbedaeb8f296b8dc1dc335f2e485ce94b02e43054c642'
-            '2c8a96b3404712c7f7c9d97697bf89362fb0c08795e984c0b37683788ab32ad5')
+            '2c8a96b3404712c7f7c9d97697bf89362fb0c08795e984c0b37683788ab32ad5'
+            'a96fb714db831f0848d1ed4245f9c7bf5c83afb4d25174b06c38b7fdff3b4dbc')
 
 user_patcher() {
 	# To patch the user because all your base are belong to us
@@ -673,6 +675,17 @@ prepare() {
   fi
   if [ "$CONDITION10" == "y" ] || [ "$_zfsfix" == "true" ]; then
     patch -Np1 -i ../0011-ZFS-fix.patch
+  fi
+
+  # umip emulation support
+  if [ -z "$_umip_instruction_emulation" ]; then
+    plain ""
+    plain "Enable support for emulation of the SGDT, SIDT, and SMSW instructions for 64-bit processes?"
+    plain "May help with crashing in certain 64-bit Windows games under Wine, on UMIP-enabled systems."
+    read -rp "`echo $'    > N/y : '`" CONDITION11;
+  fi
+  if [ "$CONDITION11" == "y" ] || [ "$_umip_instruction_emulation" == "true" ]; then
+    patch -Np1 -i ../0013-umip-instruction-emulation.patch
   fi
 
   # userpatches

--- a/linux51-tkg/customization.cfg
+++ b/linux51-tkg/customization.cfg
@@ -101,6 +101,9 @@ _zfsfix=""
 # A selection of patches from Zen/Liquorix kernel and additional tweaks for a better gaming experience (ZENIFY) - Default is "true"
 _zenify="true"
 
+# Set to true to enable emulation of the SGDT, SIDT, and SMSW instructions for 64-bit processes. May help with crashing in certain 64-bit Windows games under Wine, on UMIP-enabled systems.
+_umip_instruction_emulation=""
+
 # compiler optimization level - 1. Optimize for performance (-O2); 2. Optimize harder (-O3); 3. Optimize for size (-Os) - Kernel default is "2"
 _compileroptlevel="2"
 

--- a/linux51-tkg/linux51-tkg-patches/0013-umip-instruction-emulation.patch
+++ b/linux51-tkg/linux51-tkg-patches/0013-umip-instruction-emulation.patch
@@ -1,0 +1,194 @@
+From e86c2c8b9380440bbe761b8e2f63ab6b04a45ac2 Mon Sep 17 00:00:00 2001
+From: Brendan Shanks <bshanks@codeweavers.com>
+Date: Thu, 5 Sep 2019 16:22:21 -0700
+Subject: x86/umip: Add emulation (spoofing) for UMIP covered instructions in
+ 64-bit processes as well
+
+Add emulation (spoofing) of the SGDT, SIDT, and SMSW instructions for 64-bit
+processes.
+
+Wine users have encountered a number of 64-bit Windows games that use
+these instructions (particularly SGDT), and were crashing when run on
+UMIP-enabled systems.
+
+Originally-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
+Signed-off-by: Brendan Shanks <bshanks@codeweavers.com>
+Reviewed-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
+Reviewed-by: H. Peter Anvin (Intel) <hpa@zytor.com>
+Cc: Andy Lutomirski <luto@kernel.org>
+Cc: Borislav Petkov <bp@alien8.de>
+Cc: Brian Gerst <brgerst@gmail.com>
+Cc: Denys Vlasenko <dvlasenk@redhat.com>
+Cc: Eric W. Biederman <ebiederm@xmission.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Link: https://lkml.kernel.org/r/20190905232222.14900-1-bshanks@codeweavers.com
+[ Minor edits: capitalization, added 'spoofing' wording. ]
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+---
+ arch/x86/kernel/umip.c | 65 +++++++++++++++++++++++++++++---------------------
+ 1 file changed, 38 insertions(+), 27 deletions(-)
+
+diff --git a/arch/x86/kernel/umip.c b/arch/x86/kernel/umip.c
+index 5b345add550f..548fefed71ee 100644
+--- a/arch/x86/kernel/umip.c
++++ b/arch/x86/kernel/umip.c
+@@ -19,7 +19,7 @@
+ /** DOC: Emulation for User-Mode Instruction Prevention (UMIP)
+  *
+  * The feature User-Mode Instruction Prevention present in recent Intel
+- * processor prevents a group of instructions (sgdt, sidt, sldt, smsw, and str)
++ * processor prevents a group of instructions (SGDT, SIDT, SLDT, SMSW and STR)
+  * from being executed with CPL > 0. Otherwise, a general protection fault is
+  * issued.
+  *
+@@ -36,8 +36,8 @@
+  * DOSEMU2) rely on this subset of instructions to function.
+  *
+  * The instructions protected by UMIP can be split in two groups. Those which
+- * return a kernel memory address (sgdt and sidt) and those which return a
+- * value (sldt, str and smsw).
++ * return a kernel memory address (SGDT and SIDT) and those which return a
++ * value (SLDT, STR and SMSW).
+  *
+  * For the instructions that return a kernel memory address, applications
+  * such as WineHQ rely on the result being located in the kernel memory space,
+@@ -45,15 +45,13 @@
+  * value that, lies close to the top of the kernel memory. The limit for the GDT
+  * and the IDT are set to zero.
+  *
+- * Given that sldt and str are not commonly used in programs that run on WineHQ
++ * Given that SLDT and STR are not commonly used in programs that run on WineHQ
+  * or DOSEMU2, they are not emulated.
+  *
+  * The instruction smsw is emulated to return the value that the register CR0
+  * has at boot time as set in the head_32.
+  *
+- * Also, emulation is provided only for 32-bit processes; 64-bit processes
+- * that attempt to use the instructions that UMIP protects will receive the
+- * SIGSEGV signal issued as a consequence of the general protection fault.
++ * Emulation is provided for both 32-bit and 64-bit processes.
+  *
+  * Care is taken to appropriately emulate the results when segmentation is
+  * used. That is, rather than relying on USER_DS and USER_CS, the function
+@@ -63,17 +61,18 @@
+  * application uses a local descriptor table.
+  */
+ 
+-#define UMIP_DUMMY_GDT_BASE 0xfffe0000
+-#define UMIP_DUMMY_IDT_BASE 0xffff0000
++#define UMIP_DUMMY_GDT_BASE 0xfffffffffffe0000ULL
++#define UMIP_DUMMY_IDT_BASE 0xffffffffffff0000ULL
+ 
+ /*
+  * The SGDT and SIDT instructions store the contents of the global descriptor
+  * table and interrupt table registers, respectively. The destination is a
+  * memory operand of X+2 bytes. X bytes are used to store the base address of
+- * the table and 2 bytes are used to store the limit. In 32-bit processes, the
+- * only processes for which emulation is provided, X has a value of 4.
++ * the table and 2 bytes are used to store the limit. In 32-bit processes X
++ * has a value of 4, in 64-bit processes X has a value of 8.
+  */
+-#define UMIP_GDT_IDT_BASE_SIZE 4
++#define UMIP_GDT_IDT_BASE_SIZE_64BIT 8
++#define UMIP_GDT_IDT_BASE_SIZE_32BIT 4
+ #define UMIP_GDT_IDT_LIMIT_SIZE 2
+ 
+ #define	UMIP_INST_SGDT	0	/* 0F 01 /0 */
+@@ -189,6 +188,7 @@ static int identify_insn(struct insn *insn)
+  * @umip_inst:	A constant indicating the instruction to emulate
+  * @data:	Buffer into which the dummy result is stored
+  * @data_size:	Size of the emulated result
++ * @x86_64:	true if process is 64-bit, false otherwise
+  *
+  * Emulate an instruction protected by UMIP and provide a dummy result. The
+  * result of the emulation is saved in @data. The size of the results depends
+@@ -202,11 +202,8 @@ static int identify_insn(struct insn *insn)
+  * 0 on success, -EINVAL on error while emulating.
+  */
+ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+-			     unsigned char *data, int *data_size)
++			     unsigned char *data, int *data_size, bool x86_64)
+ {
+-	unsigned long dummy_base_addr, dummy_value;
+-	unsigned short dummy_limit = 0;
+-
+ 	if (!data || !data_size || !insn)
+ 		return -EINVAL;
+ 	/*
+@@ -219,6 +216,9 @@ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+ 	 * is always returned irrespective of the operand size.
+ 	 */
+ 	if (umip_inst == UMIP_INST_SGDT || umip_inst == UMIP_INST_SIDT) {
++		u64 dummy_base_addr;
++		u16 dummy_limit = 0;
++
+ 		/* SGDT and SIDT do not use registers operands. */
+ 		if (X86_MODRM_MOD(insn->modrm.value) == 3)
+ 			return -EINVAL;
+@@ -228,13 +228,24 @@ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+ 		else
+ 			dummy_base_addr = UMIP_DUMMY_IDT_BASE;
+ 
+-		*data_size = UMIP_GDT_IDT_LIMIT_SIZE + UMIP_GDT_IDT_BASE_SIZE;
++		/*
++		 * 64-bit processes use the entire dummy base address.
++		 * 32-bit processes use the lower 32 bits of the base address.
++		 * dummy_base_addr is always 64 bits, but we memcpy the correct
++		 * number of bytes from it to the destination.
++		 */
++		if (x86_64)
++			*data_size = UMIP_GDT_IDT_BASE_SIZE_64BIT;
++		else
++			*data_size = UMIP_GDT_IDT_BASE_SIZE_32BIT;
++
++		memcpy(data + 2, &dummy_base_addr, *data_size);
+ 
+-		memcpy(data + 2, &dummy_base_addr, UMIP_GDT_IDT_BASE_SIZE);
++		*data_size += UMIP_GDT_IDT_LIMIT_SIZE;
+ 		memcpy(data, &dummy_limit, UMIP_GDT_IDT_LIMIT_SIZE);
+ 
+ 	} else if (umip_inst == UMIP_INST_SMSW) {
+-		dummy_value = CR0_STATE;
++		unsigned long dummy_value = CR0_STATE;
+ 
+ 		/*
+ 		 * Even though the CR0 register has 4 bytes, the number
+@@ -290,11 +301,10 @@ static void force_sig_info_umip_fault(void __user *addr, struct pt_regs *regs)
+  * fixup_umip_exception() - Fixup a general protection fault caused by UMIP
+  * @regs:	Registers as saved when entering the #GP handler
+  *
+- * The instructions sgdt, sidt, str, smsw, sldt cause a general protection
+- * fault if executed with CPL > 0 (i.e., from user space). If the offending
+- * user-space process is not in long mode, this function fixes the exception
+- * up and provides dummy results for sgdt, sidt and smsw; str and sldt are not
+- * fixed up. Also long mode user-space processes are not fixed up.
++ * The instructions SGDT, SIDT, STR, SMSW and SLDT cause a general protection
++ * fault if executed with CPL > 0 (i.e., from user space). This function fixes
++ * the exception up and provides dummy results for SGDT, SIDT and SMSW; STR
++ * and SLDT are not fixed up.
+  *
+  * If operands are memory addresses, results are copied to user-space memory as
+  * indicated by the instruction pointed by eIP using the registers indicated in
+@@ -373,13 +383,14 @@ bool fixup_umip_exception(struct pt_regs *regs)
+ 	umip_pr_warning(regs, "%s instruction cannot be used by applications.\n",
+ 			umip_insns[umip_inst]);
+ 
+-	/* Do not emulate SLDT, STR or user long mode processes. */
+-	if (umip_inst == UMIP_INST_STR || umip_inst == UMIP_INST_SLDT || user_64bit_mode(regs))
++	/* Do not emulate (spoof) SLDT or STR. */
++	if (umip_inst == UMIP_INST_STR || umip_inst == UMIP_INST_SLDT)
+ 		return false;
+ 
+ 	umip_pr_warning(regs, "For now, expensive software emulation returns the result.\n");
+ 
+-	if (emulate_umip_insn(&insn, umip_inst, dummy_data, &dummy_data_size))
++	if (emulate_umip_insn(&insn, umip_inst, dummy_data, &dummy_data_size,
++			      user_64bit_mode(regs)))
+ 		return false;
+ 
+ 	/*
+-- 
+cgit 1.2-0.3.lf.el7
+

--- a/linux52-tkg/PKGBUILD
+++ b/linux52-tkg/PKGBUILD
@@ -84,7 +84,7 @@ pkgname=("${pkgbase}" "${pkgbase}-headers")
 _basekernel=5.2
 _sub=15
 pkgver="${_basekernel}"."${_sub}"
-pkgrel=30
+pkgrel=31
 arch=('x86_64') # no i686 in here
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -121,6 +121,7 @@ source=("https://www.kernel.org/pub/linux/kernel/v5.x/linux-${_basekernel}.tar.x
         0012-v5.2-fsync.patch
         0013-linux-hardened.patch
         #0014-bcachefs.patch
+        0015-umip-instruction-emulation.patch
 )
 sha256sums=('54ad66f672e1a831b574f5e704e8a05f1e6180a8245d4bdd811208a6cb0ac1e7'
             '7efc97baaa7d6760df8a10c882c1b8ad4aa06f24d201c79344571c01d1426590'
@@ -143,7 +144,8 @@ sha256sums=('54ad66f672e1a831b574f5e704e8a05f1e6180a8245d4bdd811208a6cb0ac1e7'
             '08804ef214e61000e6f54f393ddd3313ea9f3934859fdcaa69c78b5f393acdce'
             'dc4f939085d2dc6e6ebdbedaeb8f296b8dc1dc335f2e485ce94b02e43054c642'
             '3fc0b0fee9a83bf9e0afe7392351d57fa76e1325b1220a5220575fca6bde111a'
-            'a70f51d8d399cbc37b998dc9111c2b7e584d89bfc1db78b78be34b84b0478921')
+            'a70f51d8d399cbc37b998dc9111c2b7e584d89bfc1db78b78be34b84b0478921'
+            'a96fb714db831f0848d1ed4245f9c7bf5c83afb4d25174b06c38b7fdff3b4dbc')
 
 user_patcher() {
 	# To patch the user because all your base are belong to us
@@ -684,6 +686,17 @@ prepare() {
   fi
   if [ "$CONDITION10" == "y" ] || [ "$_fsync" == "true" ]; then
     patch -Np1 -i ../0012-v5.2-fsync.patch
+  fi
+
+  # umip emulation support
+  if [ -z "$_umip_instruction_emulation" ]; then
+    plain ""
+    plain "Enable support for emulation of the SGDT, SIDT, and SMSW instructions for 64-bit processes?"
+    plain "May help with crashing in certain 64-bit Windows games under Wine, on UMIP-enabled systems."
+    read -rp "`echo $'    > N/y : '`" CONDITION11;
+  fi
+  if [ "$CONDITION11" == "y" ] || [ "$_umip_instruction_emulation" == "true" ]; then
+    patch -Np1 -i ../0015-umip-instruction-emulation.patch
   fi
 
   # userpatches

--- a/linux52-tkg/customization.cfg
+++ b/linux52-tkg/customization.cfg
@@ -102,6 +102,9 @@ _fsync=""
 # A selection of patches from Zen/Liquorix kernel and additional tweaks for a better gaming experience (ZENIFY) - Default is "true"
 _zenify="true"
 
+# Set to true to enable emulation of the SGDT, SIDT, and SMSW instructions for 64-bit processes. May help with crashing in certain 64-bit Windows games under Wine, on UMIP-enabled systems.
+_umip_instruction_emulation=""
+
 # compiler optimization level - 1. Optimize for performance (-O2); 2. Optimize harder (-O3); 3. Optimize for size (-Os) - Kernel default is "2"
 _compileroptlevel="2"
 

--- a/linux52-tkg/linux52-tkg-patches/0015-umip-instruction-emulation.patch
+++ b/linux52-tkg/linux52-tkg-patches/0015-umip-instruction-emulation.patch
@@ -1,0 +1,194 @@
+From e86c2c8b9380440bbe761b8e2f63ab6b04a45ac2 Mon Sep 17 00:00:00 2001
+From: Brendan Shanks <bshanks@codeweavers.com>
+Date: Thu, 5 Sep 2019 16:22:21 -0700
+Subject: x86/umip: Add emulation (spoofing) for UMIP covered instructions in
+ 64-bit processes as well
+
+Add emulation (spoofing) of the SGDT, SIDT, and SMSW instructions for 64-bit
+processes.
+
+Wine users have encountered a number of 64-bit Windows games that use
+these instructions (particularly SGDT), and were crashing when run on
+UMIP-enabled systems.
+
+Originally-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
+Signed-off-by: Brendan Shanks <bshanks@codeweavers.com>
+Reviewed-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
+Reviewed-by: H. Peter Anvin (Intel) <hpa@zytor.com>
+Cc: Andy Lutomirski <luto@kernel.org>
+Cc: Borislav Petkov <bp@alien8.de>
+Cc: Brian Gerst <brgerst@gmail.com>
+Cc: Denys Vlasenko <dvlasenk@redhat.com>
+Cc: Eric W. Biederman <ebiederm@xmission.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Link: https://lkml.kernel.org/r/20190905232222.14900-1-bshanks@codeweavers.com
+[ Minor edits: capitalization, added 'spoofing' wording. ]
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+---
+ arch/x86/kernel/umip.c | 65 +++++++++++++++++++++++++++++---------------------
+ 1 file changed, 38 insertions(+), 27 deletions(-)
+
+diff --git a/arch/x86/kernel/umip.c b/arch/x86/kernel/umip.c
+index 5b345add550f..548fefed71ee 100644
+--- a/arch/x86/kernel/umip.c
++++ b/arch/x86/kernel/umip.c
+@@ -19,7 +19,7 @@
+ /** DOC: Emulation for User-Mode Instruction Prevention (UMIP)
+  *
+  * The feature User-Mode Instruction Prevention present in recent Intel
+- * processor prevents a group of instructions (sgdt, sidt, sldt, smsw, and str)
++ * processor prevents a group of instructions (SGDT, SIDT, SLDT, SMSW and STR)
+  * from being executed with CPL > 0. Otherwise, a general protection fault is
+  * issued.
+  *
+@@ -36,8 +36,8 @@
+  * DOSEMU2) rely on this subset of instructions to function.
+  *
+  * The instructions protected by UMIP can be split in two groups. Those which
+- * return a kernel memory address (sgdt and sidt) and those which return a
+- * value (sldt, str and smsw).
++ * return a kernel memory address (SGDT and SIDT) and those which return a
++ * value (SLDT, STR and SMSW).
+  *
+  * For the instructions that return a kernel memory address, applications
+  * such as WineHQ rely on the result being located in the kernel memory space,
+@@ -45,15 +45,13 @@
+  * value that, lies close to the top of the kernel memory. The limit for the GDT
+  * and the IDT are set to zero.
+  *
+- * Given that sldt and str are not commonly used in programs that run on WineHQ
++ * Given that SLDT and STR are not commonly used in programs that run on WineHQ
+  * or DOSEMU2, they are not emulated.
+  *
+  * The instruction smsw is emulated to return the value that the register CR0
+  * has at boot time as set in the head_32.
+  *
+- * Also, emulation is provided only for 32-bit processes; 64-bit processes
+- * that attempt to use the instructions that UMIP protects will receive the
+- * SIGSEGV signal issued as a consequence of the general protection fault.
++ * Emulation is provided for both 32-bit and 64-bit processes.
+  *
+  * Care is taken to appropriately emulate the results when segmentation is
+  * used. That is, rather than relying on USER_DS and USER_CS, the function
+@@ -63,17 +61,18 @@
+  * application uses a local descriptor table.
+  */
+ 
+-#define UMIP_DUMMY_GDT_BASE 0xfffe0000
+-#define UMIP_DUMMY_IDT_BASE 0xffff0000
++#define UMIP_DUMMY_GDT_BASE 0xfffffffffffe0000ULL
++#define UMIP_DUMMY_IDT_BASE 0xffffffffffff0000ULL
+ 
+ /*
+  * The SGDT and SIDT instructions store the contents of the global descriptor
+  * table and interrupt table registers, respectively. The destination is a
+  * memory operand of X+2 bytes. X bytes are used to store the base address of
+- * the table and 2 bytes are used to store the limit. In 32-bit processes, the
+- * only processes for which emulation is provided, X has a value of 4.
++ * the table and 2 bytes are used to store the limit. In 32-bit processes X
++ * has a value of 4, in 64-bit processes X has a value of 8.
+  */
+-#define UMIP_GDT_IDT_BASE_SIZE 4
++#define UMIP_GDT_IDT_BASE_SIZE_64BIT 8
++#define UMIP_GDT_IDT_BASE_SIZE_32BIT 4
+ #define UMIP_GDT_IDT_LIMIT_SIZE 2
+ 
+ #define	UMIP_INST_SGDT	0	/* 0F 01 /0 */
+@@ -189,6 +188,7 @@ static int identify_insn(struct insn *insn)
+  * @umip_inst:	A constant indicating the instruction to emulate
+  * @data:	Buffer into which the dummy result is stored
+  * @data_size:	Size of the emulated result
++ * @x86_64:	true if process is 64-bit, false otherwise
+  *
+  * Emulate an instruction protected by UMIP and provide a dummy result. The
+  * result of the emulation is saved in @data. The size of the results depends
+@@ -202,11 +202,8 @@ static int identify_insn(struct insn *insn)
+  * 0 on success, -EINVAL on error while emulating.
+  */
+ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+-			     unsigned char *data, int *data_size)
++			     unsigned char *data, int *data_size, bool x86_64)
+ {
+-	unsigned long dummy_base_addr, dummy_value;
+-	unsigned short dummy_limit = 0;
+-
+ 	if (!data || !data_size || !insn)
+ 		return -EINVAL;
+ 	/*
+@@ -219,6 +216,9 @@ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+ 	 * is always returned irrespective of the operand size.
+ 	 */
+ 	if (umip_inst == UMIP_INST_SGDT || umip_inst == UMIP_INST_SIDT) {
++		u64 dummy_base_addr;
++		u16 dummy_limit = 0;
++
+ 		/* SGDT and SIDT do not use registers operands. */
+ 		if (X86_MODRM_MOD(insn->modrm.value) == 3)
+ 			return -EINVAL;
+@@ -228,13 +228,24 @@ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+ 		else
+ 			dummy_base_addr = UMIP_DUMMY_IDT_BASE;
+ 
+-		*data_size = UMIP_GDT_IDT_LIMIT_SIZE + UMIP_GDT_IDT_BASE_SIZE;
++		/*
++		 * 64-bit processes use the entire dummy base address.
++		 * 32-bit processes use the lower 32 bits of the base address.
++		 * dummy_base_addr is always 64 bits, but we memcpy the correct
++		 * number of bytes from it to the destination.
++		 */
++		if (x86_64)
++			*data_size = UMIP_GDT_IDT_BASE_SIZE_64BIT;
++		else
++			*data_size = UMIP_GDT_IDT_BASE_SIZE_32BIT;
++
++		memcpy(data + 2, &dummy_base_addr, *data_size);
+ 
+-		memcpy(data + 2, &dummy_base_addr, UMIP_GDT_IDT_BASE_SIZE);
++		*data_size += UMIP_GDT_IDT_LIMIT_SIZE;
+ 		memcpy(data, &dummy_limit, UMIP_GDT_IDT_LIMIT_SIZE);
+ 
+ 	} else if (umip_inst == UMIP_INST_SMSW) {
+-		dummy_value = CR0_STATE;
++		unsigned long dummy_value = CR0_STATE;
+ 
+ 		/*
+ 		 * Even though the CR0 register has 4 bytes, the number
+@@ -290,11 +301,10 @@ static void force_sig_info_umip_fault(void __user *addr, struct pt_regs *regs)
+  * fixup_umip_exception() - Fixup a general protection fault caused by UMIP
+  * @regs:	Registers as saved when entering the #GP handler
+  *
+- * The instructions sgdt, sidt, str, smsw, sldt cause a general protection
+- * fault if executed with CPL > 0 (i.e., from user space). If the offending
+- * user-space process is not in long mode, this function fixes the exception
+- * up and provides dummy results for sgdt, sidt and smsw; str and sldt are not
+- * fixed up. Also long mode user-space processes are not fixed up.
++ * The instructions SGDT, SIDT, STR, SMSW and SLDT cause a general protection
++ * fault if executed with CPL > 0 (i.e., from user space). This function fixes
++ * the exception up and provides dummy results for SGDT, SIDT and SMSW; STR
++ * and SLDT are not fixed up.
+  *
+  * If operands are memory addresses, results are copied to user-space memory as
+  * indicated by the instruction pointed by eIP using the registers indicated in
+@@ -373,13 +383,14 @@ bool fixup_umip_exception(struct pt_regs *regs)
+ 	umip_pr_warning(regs, "%s instruction cannot be used by applications.\n",
+ 			umip_insns[umip_inst]);
+ 
+-	/* Do not emulate SLDT, STR or user long mode processes. */
+-	if (umip_inst == UMIP_INST_STR || umip_inst == UMIP_INST_SLDT || user_64bit_mode(regs))
++	/* Do not emulate (spoof) SLDT or STR. */
++	if (umip_inst == UMIP_INST_STR || umip_inst == UMIP_INST_SLDT)
+ 		return false;
+ 
+ 	umip_pr_warning(regs, "For now, expensive software emulation returns the result.\n");
+ 
+-	if (emulate_umip_insn(&insn, umip_inst, dummy_data, &dummy_data_size))
++	if (emulate_umip_insn(&insn, umip_inst, dummy_data, &dummy_data_size,
++			      user_64bit_mode(regs)))
+ 		return false;
+ 
+ 	/*
+-- 
+cgit 1.2-0.3.lf.el7
+

--- a/linux53-tkg/PKGBUILD
+++ b/linux53-tkg/PKGBUILD
@@ -84,7 +84,7 @@ pkgname=("${pkgbase}" "${pkgbase}-headers")
 _basekernel=5.3
 _sub=0
 pkgver="${_basekernel}"."${_sub}"
-pkgrel=2
+pkgrel=3
 arch=('x86_64') # no i686 in here
 url="http://www.kernel.org/"
 license=('GPL2')
@@ -115,6 +115,7 @@ source=("https://www.kernel.org/pub/linux/kernel/v5.x/linux-${_basekernel}.tar.x
         0008-drm-amd-powerplay-force-the-trim-of-the-mclk-dpm-levels-if-OD-is-enabled.patch
         0009-glitched-bmq.patch
         0009-v5.3_bmq100.patch
+        0010-umip-instruction-emulation.patch
 )
 sha256sums=('78f3c397513cf4ff0f96aa7d09a921d003e08fa97c09e0bb71d88211b40567b2'
             'd2df45d77ff5f9d9bc2e44e69cd3727a2ad5a7e1c822bcc1be0c54ac3b6c858b'
@@ -132,7 +133,8 @@ sha256sums=('78f3c397513cf4ff0f96aa7d09a921d003e08fa97c09e0bb71d88211b40567b2'
             '2d9260b80b43bbd605cf420d6bd53aa7262103dfd77196ba590ece5600b6dc0d'
             '8296024e664a4957c0f79940cf4842c70f7d82b40b5fdccdfe055e62f9d58d40'
             '3832f828a9f402b153fc9a6829c5a4eaf6091804bcda3a0423c8e1b57e26420d'
-            '4349ee052909a12f04a9a3e2ede01beafa569eca02458ecb2aebc7a0e4a43cac')
+            '4349ee052909a12f04a9a3e2ede01beafa569eca02458ecb2aebc7a0e4a43cac'
+            'a96fb714db831f0848d1ed4245f9c7bf5c83afb4d25174b06c38b7fdff3b4dbc')
 
 user_patcher() {
 	# To patch the user because all your base are belong to us
@@ -662,6 +664,17 @@ prepare() {
   fi
   if [ "$CONDITION9" == "y" ] || [ "$_fsync" == "true" ]; then
     patch -Np1 -i ../0007-v5.3-fsync.patch
+  fi
+
+  # umip emulation support
+  if [ -z "$_umip_instruction_emulation" ]; then
+    plain ""
+    plain "Enable support for emulation of the SGDT, SIDT, and SMSW instructions for 64-bit processes?"
+    plain "May help with crashing in certain 64-bit Windows games under Wine, on UMIP-enabled systems."
+    read -rp "`echo $'    > N/y : '`" CONDITION10;
+  fi
+  if [ "$CONDITION10" == "y" ] || [ "$_umip_instruction_emulation" == "true" ]; then
+    patch -Np1 -i ../0010-umip-instruction-emulation.patch
   fi
 
   # userpatches

--- a/linux53-tkg/customization.cfg
+++ b/linux53-tkg/customization.cfg
@@ -95,6 +95,9 @@ _fsync=""
 # A selection of patches from Zen/Liquorix kernel and additional tweaks for a better gaming experience (ZENIFY) - Default is "true"
 _zenify="true"
 
+# Set to true to enable emulation of the SGDT, SIDT, and SMSW instructions for 64-bit processes. May help with crashing in certain 64-bit Windows games under Wine, on UMIP-enabled systems.
+_umip_instruction_emulation=""
+
 # compiler optimization level - 1. Optimize for performance (-O2); 2. Optimize harder (-O3); 3. Optimize for size (-Os) - Kernel default is "2"
 _compileroptlevel="2"
 

--- a/linux53-tkg/linux53-tkg-patches/0010-umip-instruction-emulation.patch
+++ b/linux53-tkg/linux53-tkg-patches/0010-umip-instruction-emulation.patch
@@ -1,0 +1,194 @@
+From e86c2c8b9380440bbe761b8e2f63ab6b04a45ac2 Mon Sep 17 00:00:00 2001
+From: Brendan Shanks <bshanks@codeweavers.com>
+Date: Thu, 5 Sep 2019 16:22:21 -0700
+Subject: x86/umip: Add emulation (spoofing) for UMIP covered instructions in
+ 64-bit processes as well
+
+Add emulation (spoofing) of the SGDT, SIDT, and SMSW instructions for 64-bit
+processes.
+
+Wine users have encountered a number of 64-bit Windows games that use
+these instructions (particularly SGDT), and were crashing when run on
+UMIP-enabled systems.
+
+Originally-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
+Signed-off-by: Brendan Shanks <bshanks@codeweavers.com>
+Reviewed-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
+Reviewed-by: H. Peter Anvin (Intel) <hpa@zytor.com>
+Cc: Andy Lutomirski <luto@kernel.org>
+Cc: Borislav Petkov <bp@alien8.de>
+Cc: Brian Gerst <brgerst@gmail.com>
+Cc: Denys Vlasenko <dvlasenk@redhat.com>
+Cc: Eric W. Biederman <ebiederm@xmission.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Link: https://lkml.kernel.org/r/20190905232222.14900-1-bshanks@codeweavers.com
+[ Minor edits: capitalization, added 'spoofing' wording. ]
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+---
+ arch/x86/kernel/umip.c | 65 +++++++++++++++++++++++++++++---------------------
+ 1 file changed, 38 insertions(+), 27 deletions(-)
+
+diff --git a/arch/x86/kernel/umip.c b/arch/x86/kernel/umip.c
+index 5b345add550f..548fefed71ee 100644
+--- a/arch/x86/kernel/umip.c
++++ b/arch/x86/kernel/umip.c
+@@ -19,7 +19,7 @@
+ /** DOC: Emulation for User-Mode Instruction Prevention (UMIP)
+  *
+  * The feature User-Mode Instruction Prevention present in recent Intel
+- * processor prevents a group of instructions (sgdt, sidt, sldt, smsw, and str)
++ * processor prevents a group of instructions (SGDT, SIDT, SLDT, SMSW and STR)
+  * from being executed with CPL > 0. Otherwise, a general protection fault is
+  * issued.
+  *
+@@ -36,8 +36,8 @@
+  * DOSEMU2) rely on this subset of instructions to function.
+  *
+  * The instructions protected by UMIP can be split in two groups. Those which
+- * return a kernel memory address (sgdt and sidt) and those which return a
+- * value (sldt, str and smsw).
++ * return a kernel memory address (SGDT and SIDT) and those which return a
++ * value (SLDT, STR and SMSW).
+  *
+  * For the instructions that return a kernel memory address, applications
+  * such as WineHQ rely on the result being located in the kernel memory space,
+@@ -45,15 +45,13 @@
+  * value that, lies close to the top of the kernel memory. The limit for the GDT
+  * and the IDT are set to zero.
+  *
+- * Given that sldt and str are not commonly used in programs that run on WineHQ
++ * Given that SLDT and STR are not commonly used in programs that run on WineHQ
+  * or DOSEMU2, they are not emulated.
+  *
+  * The instruction smsw is emulated to return the value that the register CR0
+  * has at boot time as set in the head_32.
+  *
+- * Also, emulation is provided only for 32-bit processes; 64-bit processes
+- * that attempt to use the instructions that UMIP protects will receive the
+- * SIGSEGV signal issued as a consequence of the general protection fault.
++ * Emulation is provided for both 32-bit and 64-bit processes.
+  *
+  * Care is taken to appropriately emulate the results when segmentation is
+  * used. That is, rather than relying on USER_DS and USER_CS, the function
+@@ -63,17 +61,18 @@
+  * application uses a local descriptor table.
+  */
+ 
+-#define UMIP_DUMMY_GDT_BASE 0xfffe0000
+-#define UMIP_DUMMY_IDT_BASE 0xffff0000
++#define UMIP_DUMMY_GDT_BASE 0xfffffffffffe0000ULL
++#define UMIP_DUMMY_IDT_BASE 0xffffffffffff0000ULL
+ 
+ /*
+  * The SGDT and SIDT instructions store the contents of the global descriptor
+  * table and interrupt table registers, respectively. The destination is a
+  * memory operand of X+2 bytes. X bytes are used to store the base address of
+- * the table and 2 bytes are used to store the limit. In 32-bit processes, the
+- * only processes for which emulation is provided, X has a value of 4.
++ * the table and 2 bytes are used to store the limit. In 32-bit processes X
++ * has a value of 4, in 64-bit processes X has a value of 8.
+  */
+-#define UMIP_GDT_IDT_BASE_SIZE 4
++#define UMIP_GDT_IDT_BASE_SIZE_64BIT 8
++#define UMIP_GDT_IDT_BASE_SIZE_32BIT 4
+ #define UMIP_GDT_IDT_LIMIT_SIZE 2
+ 
+ #define	UMIP_INST_SGDT	0	/* 0F 01 /0 */
+@@ -189,6 +188,7 @@ static int identify_insn(struct insn *insn)
+  * @umip_inst:	A constant indicating the instruction to emulate
+  * @data:	Buffer into which the dummy result is stored
+  * @data_size:	Size of the emulated result
++ * @x86_64:	true if process is 64-bit, false otherwise
+  *
+  * Emulate an instruction protected by UMIP and provide a dummy result. The
+  * result of the emulation is saved in @data. The size of the results depends
+@@ -202,11 +202,8 @@ static int identify_insn(struct insn *insn)
+  * 0 on success, -EINVAL on error while emulating.
+  */
+ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+-			     unsigned char *data, int *data_size)
++			     unsigned char *data, int *data_size, bool x86_64)
+ {
+-	unsigned long dummy_base_addr, dummy_value;
+-	unsigned short dummy_limit = 0;
+-
+ 	if (!data || !data_size || !insn)
+ 		return -EINVAL;
+ 	/*
+@@ -219,6 +216,9 @@ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+ 	 * is always returned irrespective of the operand size.
+ 	 */
+ 	if (umip_inst == UMIP_INST_SGDT || umip_inst == UMIP_INST_SIDT) {
++		u64 dummy_base_addr;
++		u16 dummy_limit = 0;
++
+ 		/* SGDT and SIDT do not use registers operands. */
+ 		if (X86_MODRM_MOD(insn->modrm.value) == 3)
+ 			return -EINVAL;
+@@ -228,13 +228,24 @@ static int emulate_umip_insn(struct insn *insn, int umip_inst,
+ 		else
+ 			dummy_base_addr = UMIP_DUMMY_IDT_BASE;
+ 
+-		*data_size = UMIP_GDT_IDT_LIMIT_SIZE + UMIP_GDT_IDT_BASE_SIZE;
++		/*
++		 * 64-bit processes use the entire dummy base address.
++		 * 32-bit processes use the lower 32 bits of the base address.
++		 * dummy_base_addr is always 64 bits, but we memcpy the correct
++		 * number of bytes from it to the destination.
++		 */
++		if (x86_64)
++			*data_size = UMIP_GDT_IDT_BASE_SIZE_64BIT;
++		else
++			*data_size = UMIP_GDT_IDT_BASE_SIZE_32BIT;
++
++		memcpy(data + 2, &dummy_base_addr, *data_size);
+ 
+-		memcpy(data + 2, &dummy_base_addr, UMIP_GDT_IDT_BASE_SIZE);
++		*data_size += UMIP_GDT_IDT_LIMIT_SIZE;
+ 		memcpy(data, &dummy_limit, UMIP_GDT_IDT_LIMIT_SIZE);
+ 
+ 	} else if (umip_inst == UMIP_INST_SMSW) {
+-		dummy_value = CR0_STATE;
++		unsigned long dummy_value = CR0_STATE;
+ 
+ 		/*
+ 		 * Even though the CR0 register has 4 bytes, the number
+@@ -290,11 +301,10 @@ static void force_sig_info_umip_fault(void __user *addr, struct pt_regs *regs)
+  * fixup_umip_exception() - Fixup a general protection fault caused by UMIP
+  * @regs:	Registers as saved when entering the #GP handler
+  *
+- * The instructions sgdt, sidt, str, smsw, sldt cause a general protection
+- * fault if executed with CPL > 0 (i.e., from user space). If the offending
+- * user-space process is not in long mode, this function fixes the exception
+- * up and provides dummy results for sgdt, sidt and smsw; str and sldt are not
+- * fixed up. Also long mode user-space processes are not fixed up.
++ * The instructions SGDT, SIDT, STR, SMSW and SLDT cause a general protection
++ * fault if executed with CPL > 0 (i.e., from user space). This function fixes
++ * the exception up and provides dummy results for SGDT, SIDT and SMSW; STR
++ * and SLDT are not fixed up.
+  *
+  * If operands are memory addresses, results are copied to user-space memory as
+  * indicated by the instruction pointed by eIP using the registers indicated in
+@@ -373,13 +383,14 @@ bool fixup_umip_exception(struct pt_regs *regs)
+ 	umip_pr_warning(regs, "%s instruction cannot be used by applications.\n",
+ 			umip_insns[umip_inst]);
+ 
+-	/* Do not emulate SLDT, STR or user long mode processes. */
+-	if (umip_inst == UMIP_INST_STR || umip_inst == UMIP_INST_SLDT || user_64bit_mode(regs))
++	/* Do not emulate (spoof) SLDT or STR. */
++	if (umip_inst == UMIP_INST_STR || umip_inst == UMIP_INST_SLDT)
+ 		return false;
+ 
+ 	umip_pr_warning(regs, "For now, expensive software emulation returns the result.\n");
+ 
+-	if (emulate_umip_insn(&insn, umip_inst, dummy_data, &dummy_data_size))
++	if (emulate_umip_insn(&insn, umip_inst, dummy_data, &dummy_data_size,
++			      user_64bit_mode(regs)))
+ 		return false;
+ 
+ 	/*
+-- 
+cgit 1.2-0.3.lf.el7
+


### PR DESCRIPTION
Could be useful for newer processors. I think I've done all I need to do modifying the PKGBUILD's and whatnot. Builds fine for all kernels.

Only useful until [wine is patched](https://bugs.winehq.org/show_bug.cgi?id=47571#c9) to fix this I guess

https://bugs.winehq.org/show_bug.cgi?id=47571

https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/commit/?h=x86-asm-for-linus&id=e86c2c8b9380440bbe761b8e2f63ab6b04a45ac2

https://github.com/torvalds/linux/commit/df4c0b18f2a2798f1e3ae9dcf58c024bb33e4202#diff-62728468f7c3625a13900e520e029911