### PR TITLE
Add a patch that fixes MO2 support

### DIFF
--- a/proton-tkg/README.md
+++ b/proton-tkg/README.md
@@ -77,7 +77,7 @@ You can also change their default values before building in your `proton-tkg.cfg
 
 - Proton-tkg **can** handle 32-bit prefixes. However you'll have to create such a prefix by hand as the Steam client doesn't offer such an option. Also, that prefix will have to be deleted if you want to use an official Proton build with the game bound to it.
 
-- In the userpatches folder, you'll find three patches I decided against merging in the master patch for proton-tkg. You can put them in wine-tkg-git userpatches dir if you want to use them. They might not apply cleanly on older wine bases.
+- In the userpatches folder, you'll find a few patches I decided against merging in the master patch for proton-tkg. You can put them in wine-tkg-git userpatches dir if you want to use them. They might not apply cleanly on older wine bases.
 
 - Proton-tkg builds will get installed in `~/.steam/root/compatibilitytools.d` directory. If no game is bound to use a specific Proton-tkg build, you can safely delete it. **IT IS HIGHLY RECOMMENDED TO USE THE UNINSTALL FUNCTION OF THE SCRIPT TO REMOVE SUPERFLUOUS BUILDS**
 

--- a/proton-tkg/userpatches/modorganizer2-usvfs-compat.mypatch
+++ b/proton-tkg/userpatches/modorganizer2-usvfs-compat.mypatch
@@ -1,0 +1,23 @@
+diff --git a/dlls/kernel32/file.c b/dlls/kernel32/file.c
+index 2b6a13fc0d..6798ecc8ff 100644
+--- a/dlls/kernel32/file.c
++++ b/dlls/kernel32/file.c
+@@ -754,7 +754,7 @@ HANDLE WINAPI FindFirstFileExW( LPCWSTR filename, FINDEX_INFO_LEVELS level,
+ 
+     status = NtOpenFile( &info->handle, GENERIC_READ | SYNCHRONIZE, &attr, &io,
+                          FILE_SHARE_READ | FILE_SHARE_WRITE,
+-                         FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT );
++                         FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_FOR_BACKUP_INTENT );
+ 
+     if (status != STATUS_SUCCESS)
+     {
+@@ -801,7 +801,8 @@ HANDLE WINAPI FindFirstFileExW( LPCWSTR filename, FINDEX_INFO_LEVELS level,
+         }
+ 
+         info->data_len = io.Information;
+-        if (!has_wildcard || info->data_len < info->data_size - max_entry_size)
++        /* Disable this check because USVFS underflows data_len */
++        if (!has_wildcard /*|| info->data_len < info->data_size - max_entry_size*/)
+         {
+             if (has_wildcard)  /* release unused buffer space */
+                 HeapReAlloc( GetProcessHeap(), HEAP_REALLOC_IN_PLACE_ONLY,


### PR DESCRIPTION
See the discussion and research over at https://redd.it/d3493y and https://github.com/ValveSoftware/wine/issues/67. This fixes compatibility with the USVFS filesystem that ModOrganizer 2 uses to load mods into several games (including Skyrim, FO4, etc.)

All credit to /u/whyhahm (https://github.com/qsniyg)