### PR TITLE
wine-tkg-git: disable revert-c6b6935.patch above wine cb70373

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -214,8 +214,8 @@ _nativedotnet_fix="true"
 # USVFS (Mod Organizer 2's virtual filesystem) support patch - https://github.com/Tk-Glitch/PKGBUILDS/issues/300
 _usvfs_fix="false"
 
-# Reverts c6b6935 due to https://bugs.winehq.org/show_bug.cgi?id=47752
-_c6b6935_revert="true"
+# Reverts c6b6935 due to https://bugs.winehq.org/show_bug.cgi?id=47752 - Fixed upstream with cb70373
+_c6b6935_revert="false"
 
 
 #### LEGACY PATCHES - These are for older than current master - Some are enabled by default on such trees as they aren't considered harmless

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -603,7 +603,7 @@ EOM
 	fi
 
 	# Reverts c6b6935 due to https://bugs.winehq.org/show_bug.cgi?id=47752
-	if [ "$_c6b6935_revert" == "true" ]; then
+	if [ "$_c6b6935_revert" == "true" ] && ! git merge-base --is-ancestor cb703739e5c138e3beffab321b84edb129156000 HEAD; then
 	  _patchname='revert-c6b6935.patch' && _patchmsg="Reverted c6b6935 to fix regression affecting performance negatively" && nonuser_patcher
 	fi
 


### PR DESCRIPTION
I think I've done this right?

https://github.com/wine-mirror/wine/commit/cb703739e5c138e3beffab321b84edb129156000
https://github.com/wine-staging/wine-staging/commit/6bee4b6e761613015feba1feaa8d20a569b72a4a

Changed default to false

Otherwise:
```
  -> Applying revert-c6b6935.patch
patching file dlls/winex11.drv/window.c
Reversed (or previously applied) patch detected!  Skipping patch.
2 out of 2 hunks ignored -- saving rejects to file dlls/winex11.drv/window.c.rej
==> ERROR: A failure occurred in prepare().
```