### PR TITLE
mesa-git: remove 'aco' option, add patch with difference

### DIFF
--- a/mesa-git/PKGBUILD
+++ b/mesa-git/PKGBUILD
@@ -61,17 +61,6 @@ options=(${_makepkg_options[@]})
 url="https://www.mesa3d.org"
 license=('custom')
 
-# ACO or regular tree
-if [ "$_aco" == "true" ]; then
-  _sourceurl='mesa-aco::git+https://github.com/daniel-schuermann/mesa'
-  _mesa_srcdir="mesa-aco"
-  echo "Using ACO tree" > "$_where"/last_build_config.log
-else
-  _sourceurl='mesa::git://anongit.freedesktop.org/mesa/mesa'
-  _mesa_srcdir="mesa"
-  echo "Using regular mesa tree" > "$_where"/last_build_config.log
-fi
-
 source=("$_sourceurl"
         'LICENSE'
         'llvm32.native'

--- a/mesa-git/README.md
+++ b/mesa-git/README.md
@@ -3,7 +3,6 @@
 https://gitlab.freedesktop.org/mesa/mesa
 
 You can customize key features in the `customization.cfg` file such as :
-- Using mesa ACO instead of regular mesa source : https://github.com/daniel-schuermann/mesa
 - Selecting which LLVM backend version to use
 - Enabling/disabling compilation of the lib32 package
 - Change userpatches behaviour

--- a/mesa-git/customization.cfg
+++ b/mesa-git/customization.cfg
@@ -16,9 +16,6 @@
 # Enable lib32
 _lib32=true
 
-# Use ACO source instead of regular mesa - https://github.com/daniel-schuermann/mesa
-_aco=false
-
 # Use local glesv2.pc - If you're not using libglvnd-glesv2 package from AUR
 _localglesv2pc=true
 

--- a/mesa-git/mesa-userpatches/radv_lower_sub.mymesapatch
+++ b/mesa-git/mesa-userpatches/radv_lower_sub.mymesapatch
@@ -1,0 +1,184 @@
+From 86989c48c2dece1421b6b12f8e29cbae96693000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20Sch=C3=BCrmann?=
+ <daniel.schuermann@campus.tu-berlin.de>
+Date: Fri, 29 Mar 2019 12:52:03 +0100
+Subject: [PATCH 1/2] nir: allow for isub and fsub in loop_analyze
+
+---
+ src/compiler/nir/nir_loop_analyze.c | 61 ++++++++++++-----------------
+ 1 file changed, 24 insertions(+), 37 deletions(-)
+
+diff --git a/src/compiler/nir/nir_loop_analyze.c b/src/compiler/nir/nir_loop_analyze.c
+index c2473421215..39a7470b169 100644
+--- a/src/compiler/nir/nir_loop_analyze.c
++++ b/src/compiler/nir/nir_loop_analyze.c
+@@ -658,7 +658,7 @@ get_iteration(nir_op cond_op, nir_const_value initial, nir_const_value step,
+ 
+ static bool
+ will_break_on_first_iteration(nir_const_value step,
+-                              nir_alu_type induction_base_type,
++                              nir_op add_op,
+                               unsigned trip_offset,
+                               nir_op cond_op, unsigned bit_size,
+                               nir_const_value initial,
+@@ -666,23 +666,9 @@ will_break_on_first_iteration(nir_const_value step,
+                               bool limit_rhs, bool invert_cond,
+                               unsigned execution_mode)
+ {
+-   if (trip_offset == 1) {
+-      nir_op add_op;
+-      switch (induction_base_type) {
+-      case nir_type_float:
+-         add_op = nir_op_fadd;
+-         break;
+-      case nir_type_int:
+-      case nir_type_uint:
+-         add_op = nir_op_iadd;
+-         break;
+-      default:
+-         unreachable("Unhandled induction variable base type!");
+-      }
+-
++   if (trip_offset == 1)
+       initial = eval_const_binop(add_op, bit_size, initial, step,
+                                  execution_mode);
+-   }
+ 
+    nir_const_value *src[2];
+    src[limit_rhs ? 0 : 1] = &initial;
+@@ -698,26 +684,23 @@ will_break_on_first_iteration(nir_const_value step,
+ static bool
+ test_iterations(int32_t iter_int, nir_const_value step,
+                 nir_const_value limit, nir_op cond_op, unsigned bit_size,
+-                nir_alu_type induction_base_type,
+-                nir_const_value initial, bool limit_rhs, bool invert_cond,
+-                unsigned execution_mode)
++                nir_op add_op, nir_const_value initial,
++                bool limit_rhs, bool invert_cond, unsigned execution_mode)
+ {
+    assert(nir_op_infos[cond_op].num_inputs == 2);
+ 
+    nir_const_value iter_src;
+    nir_op mul_op;
+-   nir_op add_op;
+-   switch (induction_base_type) {
+-   case nir_type_float:
++   switch (add_op) {
++   case nir_op_fadd:
++   case nir_op_fsub:
+       iter_src = nir_const_value_for_float(iter_int, bit_size);
+       mul_op = nir_op_fmul;
+-      add_op = nir_op_fadd;
+       break;
+-   case nir_type_int:
+-   case nir_type_uint:
++   case nir_op_iadd:
++   case nir_op_isub:
+       iter_src = nir_const_value_for_int(iter_int, bit_size);
+       mul_op = nir_op_imul;
+-      add_op = nir_op_iadd;
+       break;
+    default:
+       unreachable("Unhandled induction variable base type!");
+@@ -731,7 +714,7 @@ test_iterations(int32_t iter_int, nir_const_value step,
+ 
+    /* Add the initial value to the accumulated induction variable total */
+    nir_const_value add_result =
+-      eval_const_binop(add_op, bit_size, mul_result, initial, execution_mode);
++      eval_const_binop(add_op, bit_size, initial, mul_result, execution_mode);
+ 
+    nir_const_value *src[2];
+    src[limit_rhs ? 0 : 1] = &add_result;
+@@ -750,9 +733,6 @@ calculate_iterations(nir_const_value initial, nir_const_value step,
+                      nir_ssa_scalar cond, nir_op alu_op, bool limit_rhs,
+                      bool invert_cond, unsigned execution_mode)
+ {
+-   /* nir_op_isub should have been lowered away by this point */
+-   assert(alu->op != nir_op_isub);
+-
+    /* Make sure the alu type for our induction variable is compatible with the
+     * conditional alus input type. If its not something has gone really wrong.
+     */
+@@ -766,8 +746,9 @@ calculate_iterations(nir_const_value initial, nir_const_value step,
+              induction_base_type);
+    }
+ 
+-   /* Check for nsupported alu operations */
+-   if (alu->op != nir_op_iadd && alu->op != nir_op_fadd)
++   /* Check for unsupported alu operations */
++   if (alu->op != nir_op_iadd && alu->op != nir_op_isub &&
++       alu->op != nir_op_fadd && alu->op != nir_op_fsub)
+       return -1;
+ 
+    /* do-while loops can increment the starting value before the condition is
+@@ -796,13 +777,18 @@ calculate_iterations(nir_const_value initial, nir_const_value step,
+     * however if the loop condition is false on the first iteration
+     * get_iteration's assumption is broken. Handle such loops first.
+     */
+-   if (will_break_on_first_iteration(step, induction_base_type, trip_offset,
++   if (will_break_on_first_iteration(step, alu->op, trip_offset,
+                                      alu_op, bit_size, initial,
+                                      limit, limit_rhs, invert_cond,
+                                      execution_mode)) {
+       return 0;
+    }
+ 
++   if (alu->op == nir_op_isub)
++      step = eval_const_unop(nir_op_ineg, bit_size, step, execution_mode);
++   else if (alu->op == nir_op_fsub)
++      step = eval_const_unop(nir_op_fneg, bit_size, step, execution_mode);
++
+    int iter_int = get_iteration(alu_op, initial, step, limit, bit_size,
+                                 execution_mode);
+ 
+@@ -824,9 +810,8 @@ calculate_iterations(nir_const_value initial, nir_const_value step,
+    for (int bias = -1; bias <= 1; bias++) {
+       const int iter_bias = iter_int + bias;
+ 
+-      if (test_iterations(iter_bias, step, limit, alu_op, bit_size,
+-                          induction_base_type, initial,
+-                          limit_rhs, invert_cond, execution_mode)) {
++      if (test_iterations(iter_bias, step, limit, alu_op, bit_size, alu->op,
++                          initial, limit_rhs, invert_cond, execution_mode)) {
+          return iter_bias > 0 ? iter_bias - trip_offset : iter_bias;
+       }
+    }
+@@ -1064,7 +1049,9 @@ find_trip_count(loop_info_state *state, unsigned execution_mode)
+       memset(&step_val, 0, sizeof(step_val));
+       UNUSED bool found_step_value = false;
+       assert(nir_op_infos[ind_var->alu->op].num_inputs == 2);
+-      for (unsigned i = 0; i < 2; i++) {
++      bool is_sub = ind_var->alu->op == nir_op_isub ||
++                    ind_var->alu->op == nir_op_fsub;
++      for (unsigned i = is_sub ? 1 : 0; i < 2; i++) {
+          nir_ssa_scalar alu_src = nir_ssa_scalar_chase_alu_src(alu_s, i);
+          if (nir_ssa_scalar_is_const(alu_src)) {
+             found_step_value = true;
+-- 
+2.23.0
+
+
+From e864e190f0a352fa653e260d2bf8954e1674fc0a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20Sch=C3=BCrmann?= <daniel@schuermann.dev>
+Date: Thu, 19 Sep 2019 13:05:28 +0200
+Subject: [PATCH 2/2] radv/aco: disable lower_sub
+
+---
+ src/amd/vulkan/radv_shader.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/amd/vulkan/radv_shader.c b/src/amd/vulkan/radv_shader.c
+index c213b83557a..ea5eee0ad84 100644
+--- a/src/amd/vulkan/radv_shader.c
++++ b/src/amd/vulkan/radv_shader.c
+@@ -92,7 +92,6 @@ static const struct nir_shader_compiler_options nir_options_aco = {
+ 	.lower_fdiv = true,
+ 	.lower_bitfield_insert_to_bitfield_select = true,
+ 	.lower_bitfield_extract = true,
+-	.lower_sub = true, /* TODO: set this to false once !1236 is merged */
+ 	.lower_pack_snorm_2x16 = true,
+ 	.lower_pack_snorm_4x8 = true,
+ 	.lower_pack_unorm_2x16 = true,
+-- 
+2.23.0
+

--- a/mesa-git/mesa-userpatches/re-add_incorrect_pkg-config_files_with_GLVND_for_backward_compatibility.mymesarevert
+++ b/mesa-git/mesa-userpatches/re-add_incorrect_pkg-config_files_with_GLVND_for_backward_compatibility.mymesarevert
@@ -1,0 +1,122 @@
+From 93df862b6affb6b8507e40601212a58012bfa873 Mon Sep 17 00:00:00 2001
+From: Eric Engestrom <eric.engestrom@intel.com>
+Date: Thu, 19 Sep 2019 14:18:55 +0100
+Subject: meson: re-add incorrect pkg-config files with GLVND for backward
+ compatibility
+
+This is a bit counter-intuitive, but the issue is that GLVND is broken
+in versions <= 1.1.1, so we need to keep wrongly providing these files
+to cover up their mistake, otherwise the rest of the world ends up
+broken.
+
+Suggested-by: Dylan Baker <dylan@pnwbakers.com>
+Cc: mesa-stable@lists.freedesktop.org
+Signed-off-by: Eric Engestrom <eric.engestrom@intel.com>
+Reviewed-by: Dylan Baker <dylan@pnwbakers.com>
+---
+ meson.build          |  4 ++++
+ src/egl/meson.build  | 27 +++++++++++++++++----------
+ src/mapi/meson.build |  2 +-
+ src/meson.build      | 14 ++++++++++++--
+ 4 files changed, 34 insertions(+), 13 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 4a80d6a..0e46fde 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1328,6 +1328,10 @@ endif
+ dep_glvnd = null_dep
+ if with_glvnd
+   dep_glvnd = dependency('libglvnd', version : '>= 0.2.0')
++  # GLVND until commit 0dfaea2bcb7cdcc785f9 ("Add pkg-config files for EGL, GL,
++  # GLES, and GLX.") was missing its pkg-config files, forcing every vendor to
++  # provide them and the distro maintainers to resolve the conflict.
++  glvnd_missing_pc_files = dep_glvnd.version().version_compare('< 1.2.0')
+   pre_args += '-DUSE_LIBGLVND=1'
+ endif
+ 
+diff --git a/src/egl/meson.build b/src/egl/meson.build
+index 14aca2a..7038a68 100644
+--- a/src/egl/meson.build
++++ b/src/egl/meson.build
+@@ -173,18 +173,25 @@ libegl = shared_library(
+   version : egl_lib_version,
+ )
+ 
+-if not with_glvnd
+-  pkg.generate(
+-    name : 'egl',
+-    description : 'Mesa EGL Library',
+-    version : meson.project_version(),
+-    libraries : libegl,
+-    libraries_private: gl_priv_libs,
+-    requires_private : gl_priv_reqs,
+-    extra_cflags : gl_pkgconfig_c_flags,
+-  )
++# If using glvnd the pkg-config header should not point to EGL_mesa, it should
++# point to EGL. glvnd is only available on unix like platforms so adding -l
++# should be safe here
++if with_glvnd and glvnd_missing_pc_files
++  _egl = '-L${libdir} -lEGL'
++else
++  _egl = libegl
+ endif
+ 
++pkg.generate(
++  name : 'egl',
++  description : 'Mesa EGL Library',
++  version : meson.project_version(),
++  libraries : _egl,
++  libraries_private: gl_priv_libs,
++  requires_private : gl_priv_reqs,
++  extra_cflags : gl_pkgconfig_c_flags,
++)
++
+ if with_tests and prog_nm.found()
+   if with_glvnd
+     egl_symbols = files('egl-glvnd-symbols.txt')
+diff --git a/src/mapi/meson.build b/src/mapi/meson.build
+index 2c79a04..39c1dba 100644
+--- a/src/mapi/meson.build
++++ b/src/mapi/meson.build
+@@ -35,7 +35,7 @@ if with_shared_glapi
+ else
+   libglapi = []
+ endif
+-if not with_glvnd
++if not with_glvnd or glvnd_missing_pc_files
+   if with_gles1
+     subdir('es1api')
+   endif
+diff --git a/src/meson.build b/src/meson.build
+index 11e0011..ddbcd7f 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -111,12 +111,22 @@ endif
+ 
+ # This must be after at least mesa, glx, and gallium, since libgl will be
+ # defined in one of those subdirs depending on the glx provider.
+-if with_glx != 'disabled' and not with_glvnd
++if with_glx != 'disabled'
++  # If using glvnd the pkg-config header should not point to GL_mesa, it should
++  # point to GL. glvnd is only available on unix like platforms so adding -l
++  # should be safe here
++  # TODO: in the glvnd case glvnd itself should really be providing this.
++  if with_glvnd and glvnd_missing_pc_files
++    _gl = '-L${libdir} -lGL'
++  else
++    _gl = libgl
++  endif
++
+   pkg.generate(
+     name : 'gl',
+     description : 'Mesa OpenGL Library',
+     version : meson.project_version(),
+-    libraries : libgl,
++    libraries : _gl,
+     libraries_private : gl_priv_libs,
+     requires_private : gl_priv_reqs,
+     variables : ['glx_tls=yes'],
+-- 
+cgit v1.1
+


### PR DESCRIPTION
The main bulk of ACO has been merged into mesa/mesa [bar a few commits](https://gitlab.freedesktop.org/daniel-schuermann/mesa/-/branches/active). As for daniel-schuermann/mesa master, that is only 2 commits ahead of mesa/mesa master, so I've added a patch which includes those two commits. 

Closes https://github.com/Tk-Glitch/PKGBUILDS/issues/312