### PR TITLE
community/dxvk-tools: win32-nativeopt patch

### DIFF
--- a/community-patches/dxvk/nativeopt-when-using-dxvk-win32-thread-model-support.dxvkpatch
+++ b/community-patches/dxvk/nativeopt-when-using-dxvk-win32-thread-model-support.dxvkpatch
@@ -1,0 +1,36 @@
+From d5f571da7ac5dd376b8c92c5382696ec156ef738 Mon Sep 17 00:00:00 2001
+From: Tk-Glitch <ti3nou@gmail.com>
+Date: Tue, 9 Oct 2018 22:37:20 +0200
+Subject: march native
+
+
+diff --git a/build-win32.txt b/build-win32.txt
+index 463230e..b8171be 100644
+--- a/build-win32.txt
++++ b/build-win32.txt
+@@ -5,8 +5,8 @@ strip = 'i686-w64-mingw32-strip'
+ exe_wrapper = 'wine'
+ 
+ [properties]
+-c_args=['-msse', '-msse2', '-D_WIN32_WINNT=0x0601']
+-cpp_args=['-msse', '-msse2', '-D_WIN32_WINNT=0x0601']
++c_args=['-march=native', '-D_WIN32_WINNT=0x0601']
++cpp_args=['-march=native', '-D_WIN32_WINNT=0x0601']
+ c_link_args = ['-static', '-static-libgcc']
+ cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++', '-Wl,--add-stdcall-alias,--enable-stdcall-fixup']
+ 
+diff --git a/build-win64.txt b/build-win64.txt
+index d33d2da..a76124c 100644
+--- a/build-win64.txt
++++ b/build-win64.txt
+@@ -5,8 +5,8 @@
+ strip = 'x86_64-w64-mingw32-strip'
+ 
+ [properties]
+-c_args=['-D_WIN32_WINNT=0x0601']
+-cpp_args=['-D_WIN32_WINNT=0x0601']
++c_args=['-march=native', '-D_WIN32_WINNT=0x0601']
++cpp_args=['-march=native', '-D_WIN32_WINNT=0x0601']
+ c_link_args = ['-static', '-static-libgcc']
+ cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++']
+ needs_exe_wrapper = true


### PR DESCRIPTION
When using the "dxvk-win32-thread-model-support" community patch the native opt
patch fails.  This patch expects '_nativeopt="false"' in "updxvk.cfg" because
the standard native opt patch works just fine when win32-thread isn't in use.

[Ticket: None]