### PR TITLE
spirv-tools-git: produce shared libs

### DIFF
--- a/spirv-tools-git/PKGBUILD
+++ b/spirv-tools-git/PKGBUILD
@@ -62,6 +62,7 @@ build() {
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_BUILD_TYPE=Release \
       -DSPIRV_WERROR=Off \
+      -DBUILD_SHARED_LIBS=ON \
       -DSPIRV-Headers_SOURCE_DIR=${srcdir}/SPIRV-Headers
   make
 
@@ -72,6 +73,7 @@ build() {
       -DCMAKE_INSTALL_LIBDIR=lib32 \
       -DCMAKE_BUILD_TYPE=Release \
       -DSPIRV_WERROR=Off \
+      -DBUILD_SHARED_LIBS=ON \
       -DSPIRV-Headers_SOURCE_DIR=${srcdir}/SPIRV-Headers
   make
 }


### PR DESCRIPTION
generates :
```
usr/lib/libSPIRV-Tools-link.so
usr/lib/libSPIRV-Tools-opt.so
usr/lib/libSPIRV-Tools-reduce.so
usr/lib/libSPIRV-Tools.so
```

required for programs such as mpv

`mpv: error while loading shared libraries: libSPIRV-Tools.so: cannot open shared object file: No such file or directory`