### PR TITLE
community-patches: linux419/52/53: amd mclk switching patch

### DIFF
--- a/community-patches/linux419-tkg/README.md
+++ b/community-patches/linux419-tkg/README.md
@@ -1,6 +1,7 @@
 # linux419-tkg patches
 
 - 0008-drm-amd-powerplay-force-the-trim-of-the-mclk-dpm-levels-if-OD-is-enabled.mypatch : Fixes flickering on *some* AMD GPUs while using multiple monitors (https://bugs.freedesktop.org/show_bug.cgi?id=102646 https://bugs.freedesktop.org/show_bug.cgi?id=108941)
+- amd-mckl-switching.mypatch : Support mclk switching when monitors are in sync. Enable with `amdgpu.dcfeaturemask=2` (https://lists.freedesktop.org/archives/amd-gfx/2019-August/039006.html)
 - amdgpu_cursor_async_updates_for_fb_swaps.mypatch : Fixes stuttering cases on AMD GPUs (https://cgit.freedesktop.org/~agd5f/linux/commit/?h=drm-next&id=e16e37efb4c9eb7bcb9dab756c975040c5257e98)
 - amdgpu_dyn_mem_clock_75Hz_fix.mypatch : Allows dynamic video memory clocking with amdgpu and 75Hz display (https://cgit.freedesktop.org/~agd5f/linux/commit/?h=amd-staging-drm-next&id=b396b001487db18ac84d8d773d0234ac6b376dea)
 - amdgpu_extratemps-4.19.mypatch : Adds GPU hotspot temp reading on some AMD GPUs (https://github.com/matszpk/amdgpu-vega-hotspot)

--- a/community-patches/linux419-tkg/amd-mckl-switching.mypatch
+++ b/community-patches/linux419-tkg/amd-mckl-switching.mypatch
@@ -1,0 +1,146 @@
+From d5bfb566244993ca598d0986878282d9e464b348 Mon Sep 17 00:00:00 2001
+From: telans <telans@protonmail.com>
+Date: Tue, 23 Sep 2019 22:52:51 +0000
+Subject: [PATCH] support mclk switching when monitors are in sync
+
+---
+ .../gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c |  3 ++
+ .../gpu/drm/amd/display/dc/calcs/dce_calcs.c  | 33 +++++++++++++++++--
+ drivers/gpu/drm/amd/display/dc/dc.h           |  2 +-
+ drivers/gpu/drm/amd/include/amd_shared.h      |  1 +
+ .../gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c  |  7 ++--
+ .../drm/amd/powerplay/hwmgr/vega10_hwmgr.c    |  3 +-
+ 6 files changed, 42 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+index 45be7a2132bb..cd60332d0802 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+@@ -694,6 +694,9 @@ static int amdgpu_dm_init(struct amdgpu_device *adev)
+ 	if (amdgpu_dc_feature_mask & DC_FBC_MASK)
+ 		init_data.flags.fbc_support = true;
+ 
++	if (amdgpu_dc_feature_mask & DC_MULTI_MON_PP_MCLK_SWITCH_MASK)
++		init_data.flags.multi_mon_pp_mclk_switch = true;
++
+ 	init_data.flags.power_down_display_on_boot = true;
+ 
+ #ifdef CONFIG_DRM_AMD_DC_DCN2_0
+diff --git a/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c b/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c
+index 7108d51a9c5b..d83a2f3c67a8 100644
+--- a/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c
++++ b/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c
+@@ -25,6 +25,7 @@
+ 
+ #include <linux/slab.h>
+ 
++#include "resource.h"
+ #include "dm_services.h"
+ #include "dce_calcs.h"
+ #include "dc.h"
+@@ -2977,6 +2978,32 @@ static void populate_initial_data(
+ 	data->number_of_displays = num_displays;
+ }
+ 
++static bool all_displays_in_sync(const struct pipe_ctx pipe[],
++				 int pipe_count)
++{
++	const struct pipe_ctx *active_pipes[MAX_PIPES];
++	int i, num_active_pipes = 0;
++
++	for (i = 0; i < pipe_count; i++) {
++		if (!pipe[i].stream || pipe[i].top_pipe)
++			continue;
++
++		active_pipes[num_active_pipes++] = &pipe[i];
++	}
++
++	if (!num_active_pipes)
++		return false;
++
++	for (i = 1; i < num_active_pipes; ++i) {
++		if (!resource_are_streams_timing_synchronizable(
++			    active_pipes[0]->stream, active_pipes[i]->stream)) {
++			return false;
++		}
++	}
++
++	return true;
++}
++
+ /**
+  * Return:
+  *	true -	Display(s) configuration supported.
+@@ -2998,8 +3025,10 @@ bool bw_calcs(struct dc_context *ctx,
+ 
+ 	populate_initial_data(pipe, pipe_count, data);
+ 
+-	/*TODO: this should be taken out calcs output and assigned during timing sync for pplib use*/
+-	calcs_output->all_displays_in_sync = false;
++	if (ctx->dc->config.multi_mon_pp_mclk_switch)
++		calcs_output->all_displays_in_sync = all_displays_in_sync(pipe, pipe_count);
++	else
++		calcs_output->all_displays_in_sync = false;
+ 
+ 	if (data->number_of_displays != 0) {
+ 		uint8_t yclk_lvl, sclk_lvl;
+diff --git a/drivers/gpu/drm/amd/display/dc/dc.h b/drivers/gpu/drm/amd/display/dc/dc.h
+index e513028faefa..fef60704bb33 100644
+--- a/drivers/gpu/drm/amd/display/dc/dc.h
++++ b/drivers/gpu/drm/amd/display/dc/dc.h
+@@ -219,7 +219,7 @@ struct dc_config {
+ 	bool power_down_display_on_boot;
+ 	bool edp_not_connected;
+ 	bool forced_clocks;
+-
++	bool multi_mon_pp_mclk_switch;
+ };
+ 
+ enum visual_confirm {
+diff --git a/drivers/gpu/drm/amd/include/amd_shared.h b/drivers/gpu/drm/amd/include/amd_shared.h
+index a0a7211438f2..8889aaceec60 100644
+--- a/drivers/gpu/drm/amd/include/amd_shared.h
++++ b/drivers/gpu/drm/amd/include/amd_shared.h
+@@ -142,6 +142,7 @@ enum PP_FEATURE_MASK {
+ 
+ enum DC_FEATURE_MASK {
+ 	DC_FBC_MASK = 0x1,
++	DC_MULTI_MON_PP_MCLK_SWITCH_MASK = 0x2,
+ };
+ 
+ enum amd_dpm_forced_level;
+diff --git a/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c b/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c
+index 487aeee1cf8a..b107a78da714 100644
+--- a/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c
++++ b/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c
+@@ -2956,9 +2956,10 @@ static int smu7_apply_state_adjust_rules(struct pp_hwmgr *hwmgr,
+ 	if (hwmgr->display_config->num_display == 0)
+ 		disable_mclk_switching = false;
+ 	else
+-		disable_mclk_switching = ((1 < hwmgr->display_config->num_display) ||
+-					  disable_mclk_switching_for_frame_lock ||
+-					  smu7_vblank_too_short(hwmgr, hwmgr->display_config->min_vblank_time));
++		disable_mclk_switching = ((1 < hwmgr->display_config->num_display) &&
++					  !hwmgr->display_config->multi_monitor_in_sync) ||
++			disable_mclk_switching_for_frame_lock ||
++			smu7_vblank_too_short(hwmgr, hwmgr->display_config->min_vblank_time);
+ 
+ 	sclk = smu7_ps->performance_levels[0].engine_clock;
+ 	mclk = smu7_ps->performance_levels[0].memory_clock;
+diff --git a/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c b/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c
+index 3be8eb21fd6e..3c71b9a61a86 100644
+--- a/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c
++++ b/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c
+@@ -3220,7 +3220,8 @@ static int vega10_apply_state_adjust_rules(struct pp_hwmgr *hwmgr,
+ 	if (hwmgr->display_config->num_display == 0)
+ 		disable_mclk_switching = false;
+ 	else
+-		disable_mclk_switching = (hwmgr->display_config->num_display > 1) ||
++		disable_mclk_switching = ((1 < hwmgr->display_config->num_display) &&
++					  !hwmgr->display_config->multi_monitor_in_sync) ||
+ 			disable_mclk_switching_for_frame_lock ||
+ 			disable_mclk_switching_for_vr ||
+ 			force_mclk_high;
+-- 
+2.23.0
+

--- a/community-patches/linux52-tkg/README.md
+++ b/community-patches/linux52-tkg/README.md
@@ -1,6 +1,7 @@
 # linux52-tkg patches
 
 - 0008-drm-amd-powerplay-force-the-trim-of-the-mclk-dpm-levels-if-OD-is-enabled.mypatch : Fixes flickering on *some* AMD GPUs while using multiple monitors (https://bugs.freedesktop.org/show_bug.cgi?id=102646 https://bugs.freedesktop.org/show_bug.cgi?id=108941)
+- amd-mckl-switching.mypatch : Support mclk switching when monitors are in sync. Enable with `amdgpu.dcfeaturemask=2` (https://lists.freedesktop.org/archives/amd-gfx/2019-August/039006.html)
 - amdgpu_cursor_async_updates_for_fb_swaps.mypatch : Fixes stuttering cases on AMD GPUs (https://cgit.freedesktop.org/~agd5f/linux/commit/?h=drm-next&id=e16e37efb4c9eb7bcb9dab756c975040c5257e98)
 - amdgpu_dyn_mem_clock_75Hz_fix.mypatch : Allows dynamic video memory clocking with amdgpu and 75Hz display (https://cgit.freedesktop.org/~agd5f/linux/commit/?h=amd-staging-drm-next&id=b396b001487db18ac84d8d773d0234ac6b376dea)
 - amdgpu_extratemps-5.2.mypatch : Adds GPU hotspot temp reading on some AMD GPUs (https://github.com/matszpk/amdgpu-vega-hotspot)

--- a/community-patches/linux52-tkg/amd-mckl-switching.mypatch
+++ b/community-patches/linux52-tkg/amd-mckl-switching.mypatch
@@ -1,0 +1,146 @@
+From d5bfb566244993ca598d0986878282d9e464b348 Mon Sep 17 00:00:00 2001
+From: telans <telans@protonmail.com>
+Date: Tue, 23 Sep 2019 22:52:51 +0000
+Subject: [PATCH] support mclk switching when monitors are in sync
+
+---
+ .../gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c |  3 ++
+ .../gpu/drm/amd/display/dc/calcs/dce_calcs.c  | 33 +++++++++++++++++--
+ drivers/gpu/drm/amd/display/dc/dc.h           |  2 +-
+ drivers/gpu/drm/amd/include/amd_shared.h      |  1 +
+ .../gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c  |  7 ++--
+ .../drm/amd/powerplay/hwmgr/vega10_hwmgr.c    |  3 +-
+ 6 files changed, 42 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+index 45be7a2132bb..cd60332d0802 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+@@ -694,6 +694,9 @@ static int amdgpu_dm_init(struct amdgpu_device *adev)
+ 	if (amdgpu_dc_feature_mask & DC_FBC_MASK)
+ 		init_data.flags.fbc_support = true;
+ 
++	if (amdgpu_dc_feature_mask & DC_MULTI_MON_PP_MCLK_SWITCH_MASK)
++		init_data.flags.multi_mon_pp_mclk_switch = true;
++
+ 	init_data.flags.power_down_display_on_boot = true;
+ 
+ #ifdef CONFIG_DRM_AMD_DC_DCN2_0
+diff --git a/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c b/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c
+index 7108d51a9c5b..d83a2f3c67a8 100644
+--- a/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c
++++ b/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c
+@@ -25,6 +25,7 @@
+ 
+ #include <linux/slab.h>
+ 
++#include "resource.h"
+ #include "dm_services.h"
+ #include "dce_calcs.h"
+ #include "dc.h"
+@@ -2977,6 +2978,32 @@ static void populate_initial_data(
+ 	data->number_of_displays = num_displays;
+ }
+ 
++static bool all_displays_in_sync(const struct pipe_ctx pipe[],
++				 int pipe_count)
++{
++	const struct pipe_ctx *active_pipes[MAX_PIPES];
++	int i, num_active_pipes = 0;
++
++	for (i = 0; i < pipe_count; i++) {
++		if (!pipe[i].stream || pipe[i].top_pipe)
++			continue;
++
++		active_pipes[num_active_pipes++] = &pipe[i];
++	}
++
++	if (!num_active_pipes)
++		return false;
++
++	for (i = 1; i < num_active_pipes; ++i) {
++		if (!resource_are_streams_timing_synchronizable(
++			    active_pipes[0]->stream, active_pipes[i]->stream)) {
++			return false;
++		}
++	}
++
++	return true;
++}
++
+ /**
+  * Return:
+  *	true -	Display(s) configuration supported.
+@@ -2998,8 +3025,10 @@ bool bw_calcs(struct dc_context *ctx,
+ 
+ 	populate_initial_data(pipe, pipe_count, data);
+ 
+-	/*TODO: this should be taken out calcs output and assigned during timing sync for pplib use*/
+-	calcs_output->all_displays_in_sync = false;
++	if (ctx->dc->config.multi_mon_pp_mclk_switch)
++		calcs_output->all_displays_in_sync = all_displays_in_sync(pipe, pipe_count);
++	else
++		calcs_output->all_displays_in_sync = false;
+ 
+ 	if (data->number_of_displays != 0) {
+ 		uint8_t yclk_lvl, sclk_lvl;
+diff --git a/drivers/gpu/drm/amd/display/dc/dc.h b/drivers/gpu/drm/amd/display/dc/dc.h
+index e513028faefa..fef60704bb33 100644
+--- a/drivers/gpu/drm/amd/display/dc/dc.h
++++ b/drivers/gpu/drm/amd/display/dc/dc.h
+@@ -219,7 +219,7 @@ struct dc_config {
+ 	bool power_down_display_on_boot;
+ 	bool edp_not_connected;
+ 	bool forced_clocks;
+-
++	bool multi_mon_pp_mclk_switch;
+ };
+ 
+ enum visual_confirm {
+diff --git a/drivers/gpu/drm/amd/include/amd_shared.h b/drivers/gpu/drm/amd/include/amd_shared.h
+index a0a7211438f2..8889aaceec60 100644
+--- a/drivers/gpu/drm/amd/include/amd_shared.h
++++ b/drivers/gpu/drm/amd/include/amd_shared.h
+@@ -142,6 +142,7 @@ enum PP_FEATURE_MASK {
+ 
+ enum DC_FEATURE_MASK {
+ 	DC_FBC_MASK = 0x1,
++	DC_MULTI_MON_PP_MCLK_SWITCH_MASK = 0x2,
+ };
+ 
+ enum amd_dpm_forced_level;
+diff --git a/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c b/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c
+index 487aeee1cf8a..b107a78da714 100644
+--- a/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c
++++ b/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c
+@@ -2956,9 +2956,10 @@ static int smu7_apply_state_adjust_rules(struct pp_hwmgr *hwmgr,
+ 	if (hwmgr->display_config->num_display == 0)
+ 		disable_mclk_switching = false;
+ 	else
+-		disable_mclk_switching = ((1 < hwmgr->display_config->num_display) ||
+-					  disable_mclk_switching_for_frame_lock ||
+-					  smu7_vblank_too_short(hwmgr, hwmgr->display_config->min_vblank_time));
++		disable_mclk_switching = ((1 < hwmgr->display_config->num_display) &&
++					  !hwmgr->display_config->multi_monitor_in_sync) ||
++			disable_mclk_switching_for_frame_lock ||
++			smu7_vblank_too_short(hwmgr, hwmgr->display_config->min_vblank_time);
+ 
+ 	sclk = smu7_ps->performance_levels[0].engine_clock;
+ 	mclk = smu7_ps->performance_levels[0].memory_clock;
+diff --git a/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c b/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c
+index 3be8eb21fd6e..3c71b9a61a86 100644
+--- a/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c
++++ b/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c
+@@ -3220,7 +3220,8 @@ static int vega10_apply_state_adjust_rules(struct pp_hwmgr *hwmgr,
+ 	if (hwmgr->display_config->num_display == 0)
+ 		disable_mclk_switching = false;
+ 	else
+-		disable_mclk_switching = (hwmgr->display_config->num_display > 1) ||
++		disable_mclk_switching = ((1 < hwmgr->display_config->num_display) &&
++					  !hwmgr->display_config->multi_monitor_in_sync) ||
+ 			disable_mclk_switching_for_frame_lock ||
+ 			disable_mclk_switching_for_vr ||
+ 			force_mclk_high;
+-- 
+2.23.0
+

--- a/community-patches/linux53-tkg/README.md
+++ b/community-patches/linux53-tkg/README.md
@@ -1,6 +1,7 @@
 # linux53-tkg patches
 
 - 0008-drm-amd-powerplay-force-the-trim-of-the-mclk-dpm-levels-if-OD-is-enabled.mypatch : Fixes flickering on *some* AMD GPUs while using multiple monitors (https://bugs.freedesktop.org/show_bug.cgi?id=102646 https://bugs.freedesktop.org/show_bug.cgi?id=108941)
+- amd-mckl-switching.mypatch : Support mclk switching when monitors are in sync. Enable with `amdgpu.dcfeaturemask=2` (https://lists.freedesktop.org/archives/amd-gfx/2019-August/039006.html)
 - amdgpu_bulk_moves.mypatch : Increases perf on amdgpu (https://lists.freedesktop.org/archives/amd-gfx/2019-September/039982.html)
 - amdgpu_cursor_async_updates_for_fb_swaps.mypatch : Fixes stuttering cases on AMD GPUs (https://cgit.freedesktop.org/~agd5f/linux/commit/?h=drm-next&id=e16e37efb4c9eb7bcb9dab756c975040c5257e98)
 - amdgpu_dyn_mem_clock_75Hz_fix.mypatch : Allows dynamic video memory clocking with amdgpu and 75Hz display (https://cgit.freedesktop.org/~agd5f/linux/commit/?h=amd-staging-drm-next&id=b396b001487db18ac84d8d773d0234ac6b376dea)

--- a/community-patches/linux53-tkg/amd-mckl-switching.mypatch
+++ b/community-patches/linux53-tkg/amd-mckl-switching.mypatch
@@ -1,0 +1,146 @@
+From d5bfb566244993ca598d0986878282d9e464b348 Mon Sep 17 00:00:00 2001
+From: telans <telans@protonmail.com>
+Date: Tue, 23 Sep 2019 22:52:51 +0000
+Subject: [PATCH] support mclk switching when monitors are in sync
+
+---
+ .../gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c |  3 ++
+ .../gpu/drm/amd/display/dc/calcs/dce_calcs.c  | 33 +++++++++++++++++--
+ drivers/gpu/drm/amd/display/dc/dc.h           |  2 +-
+ drivers/gpu/drm/amd/include/amd_shared.h      |  1 +
+ .../gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c  |  7 ++--
+ .../drm/amd/powerplay/hwmgr/vega10_hwmgr.c    |  3 +-
+ 6 files changed, 42 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+index 45be7a2132bb..cd60332d0802 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+@@ -694,6 +694,9 @@ static int amdgpu_dm_init(struct amdgpu_device *adev)
+ 	if (amdgpu_dc_feature_mask & DC_FBC_MASK)
+ 		init_data.flags.fbc_support = true;
+ 
++	if (amdgpu_dc_feature_mask & DC_MULTI_MON_PP_MCLK_SWITCH_MASK)
++		init_data.flags.multi_mon_pp_mclk_switch = true;
++
+ 	init_data.flags.power_down_display_on_boot = true;
+ 
+ #ifdef CONFIG_DRM_AMD_DC_DCN2_0
+diff --git a/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c b/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c
+index 7108d51a9c5b..d83a2f3c67a8 100644
+--- a/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c
++++ b/drivers/gpu/drm/amd/display/dc/calcs/dce_calcs.c
+@@ -25,6 +25,7 @@
+ 
+ #include <linux/slab.h>
+ 
++#include "resource.h"
+ #include "dm_services.h"
+ #include "dce_calcs.h"
+ #include "dc.h"
+@@ -2977,6 +2978,32 @@ static void populate_initial_data(
+ 	data->number_of_displays = num_displays;
+ }
+ 
++static bool all_displays_in_sync(const struct pipe_ctx pipe[],
++				 int pipe_count)
++{
++	const struct pipe_ctx *active_pipes[MAX_PIPES];
++	int i, num_active_pipes = 0;
++
++	for (i = 0; i < pipe_count; i++) {
++		if (!pipe[i].stream || pipe[i].top_pipe)
++			continue;
++
++		active_pipes[num_active_pipes++] = &pipe[i];
++	}
++
++	if (!num_active_pipes)
++		return false;
++
++	for (i = 1; i < num_active_pipes; ++i) {
++		if (!resource_are_streams_timing_synchronizable(
++			    active_pipes[0]->stream, active_pipes[i]->stream)) {
++			return false;
++		}
++	}
++
++	return true;
++}
++
+ /**
+  * Return:
+  *	true -	Display(s) configuration supported.
+@@ -2998,8 +3025,10 @@ bool bw_calcs(struct dc_context *ctx,
+ 
+ 	populate_initial_data(pipe, pipe_count, data);
+ 
+-	/*TODO: this should be taken out calcs output and assigned during timing sync for pplib use*/
+-	calcs_output->all_displays_in_sync = false;
++	if (ctx->dc->config.multi_mon_pp_mclk_switch)
++		calcs_output->all_displays_in_sync = all_displays_in_sync(pipe, pipe_count);
++	else
++		calcs_output->all_displays_in_sync = false;
+ 
+ 	if (data->number_of_displays != 0) {
+ 		uint8_t yclk_lvl, sclk_lvl;
+diff --git a/drivers/gpu/drm/amd/display/dc/dc.h b/drivers/gpu/drm/amd/display/dc/dc.h
+index e513028faefa..fef60704bb33 100644
+--- a/drivers/gpu/drm/amd/display/dc/dc.h
++++ b/drivers/gpu/drm/amd/display/dc/dc.h
+@@ -219,7 +219,7 @@ struct dc_config {
+ 	bool power_down_display_on_boot;
+ 	bool edp_not_connected;
+ 	bool forced_clocks;
+-
++	bool multi_mon_pp_mclk_switch;
+ };
+ 
+ enum visual_confirm {
+diff --git a/drivers/gpu/drm/amd/include/amd_shared.h b/drivers/gpu/drm/amd/include/amd_shared.h
+index a0a7211438f2..8889aaceec60 100644
+--- a/drivers/gpu/drm/amd/include/amd_shared.h
++++ b/drivers/gpu/drm/amd/include/amd_shared.h
+@@ -142,6 +142,7 @@ enum PP_FEATURE_MASK {
+ 
+ enum DC_FEATURE_MASK {
+ 	DC_FBC_MASK = 0x1,
++	DC_MULTI_MON_PP_MCLK_SWITCH_MASK = 0x2,
+ };
+ 
+ enum amd_dpm_forced_level;
+diff --git a/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c b/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c
+index 487aeee1cf8a..b107a78da714 100644
+--- a/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c
++++ b/drivers/gpu/drm/amd/powerplay/hwmgr/smu7_hwmgr.c
+@@ -2956,9 +2956,10 @@ static int smu7_apply_state_adjust_rules(struct pp_hwmgr *hwmgr,
+ 	if (hwmgr->display_config->num_display == 0)
+ 		disable_mclk_switching = false;
+ 	else
+-		disable_mclk_switching = ((1 < hwmgr->display_config->num_display) ||
+-					  disable_mclk_switching_for_frame_lock ||
+-					  smu7_vblank_too_short(hwmgr, hwmgr->display_config->min_vblank_time));
++		disable_mclk_switching = ((1 < hwmgr->display_config->num_display) &&
++					  !hwmgr->display_config->multi_monitor_in_sync) ||
++			disable_mclk_switching_for_frame_lock ||
++			smu7_vblank_too_short(hwmgr, hwmgr->display_config->min_vblank_time);
+ 
+ 	sclk = smu7_ps->performance_levels[0].engine_clock;
+ 	mclk = smu7_ps->performance_levels[0].memory_clock;
+diff --git a/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c b/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c
+index 3be8eb21fd6e..3c71b9a61a86 100644
+--- a/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c
++++ b/drivers/gpu/drm/amd/powerplay/hwmgr/vega10_hwmgr.c
+@@ -3220,7 +3220,8 @@ static int vega10_apply_state_adjust_rules(struct pp_hwmgr *hwmgr,
+ 	if (hwmgr->display_config->num_display == 0)
+ 		disable_mclk_switching = false;
+ 	else
+-		disable_mclk_switching = (hwmgr->display_config->num_display > 1) ||
++		disable_mclk_switching = ((1 < hwmgr->display_config->num_display) &&
++					  !hwmgr->display_config->multi_monitor_in_sync) ||
+ 			disable_mclk_switching_for_frame_lock ||
+ 			disable_mclk_switching_for_vr ||
+ 			force_mclk_high;
+-- 
+2.23.0
+


### PR DESCRIPTION
```
This patch set enables mclk switching with multiple monitors when all
monitors are sync.  Normally mclk switching is not available with
multiple monitors because the vblank timing does not line up.  However,
if the timing is identical, the display driver can sync up the displays
in some cases.  Check for these cases and allow mclk switch when
possible.
```

https://lists.freedesktop.org/archives/amd-gfx/2019-August/039006.html

Closes #319 