### PR TITLE
nvidia-all: Fix allocator library

### DIFF
--- a/nvidia-all/PKGBUILD
+++ b/nvidia-all/PKGBUILD
@@ -691,8 +691,8 @@ nvidia-utils-tkg() {
     install -D -m755 "libnvidia-ml.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-ml.so.${pkgver}"
     install -D -m755 "libnvidia-glvkspirv.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-glvkspirv.so.${pkgver}"
 
-    # 440 series
-    if [[ -e libnvidia-allocator.so* ]]; then
+    # Allocator library
+    if [[ -e libnvidia-allocator.so.${pkgver} ]]; then
       install -D -m755 "libnvidia-allocator.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-allocator.so.${pkgver}"
     fi
 
@@ -903,6 +903,11 @@ lib32-nvidia-utils-tkg() {
     install -D -m755 "libnvidia-glcore.so.${pkgver}" "${pkgdir}/usr/lib32/libnvidia-glcore.so.${pkgver}"
     install -D -m755 "libnvidia-eglcore.so.${pkgver}" "${pkgdir}/usr/lib32/libnvidia-eglcore.so.${pkgver}"
     install -D -m755 "libnvidia-glsi.so.${pkgver}" "${pkgdir}/usr/lib32/libnvidia-glsi.so.${pkgver}"
+
+    # Allocator library
+    if [[ -e libnvidia-allocator.so.${pkgver} ]]; then
+      install -D -m755 "libnvidia-allocator.so.${pkgver}" "${pkgdir}/usr/lib32/libnvidia-allocator.so.${pkgver}"
+    fi
 
     # misc
     install -D -m755 "libnvidia-ifr.so.${pkgver}" "${pkgdir}/usr/lib32/libnvidia-ifr.so.${pkgver}"


### PR DESCRIPTION
 - The allocator library doesn't get installed because Bash's double bracket doesn't expand globs. And there's no need to use a wildcard here anyways.
- Added lib32 version of the library