### PR TITLE
vulkan-headers-git: differentiate from aur package

### DIFF
--- a/vulkan-headers-git/PKGBUILD
+++ b/vulkan-headers-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Based on Arch's PKGBUILD by Laurent Carlier <lordheavym@gmail.com>
 # Modified by Tk-Glitch <ti3nou at gmail dot com> to target git instead of tagged releases
 
-pkgname=vulkan-headers-git
+pkgname=vulkan-headers-tkg-git
 pkgver=1.1.125.r0.gd287523
 pkgrel=1
 pkgdesc="Vulkan header files"


### PR DESCRIPTION
using yay with `vulkan-headers-git` uses [this PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=vulkan-headers-git) if new commit is detected. As it says in the readme, that package is incomplete, so it's better to not have an aur helper think they're the same 