### PR TITLE
mingw:  add --force to makepkg

### DIFF
--- a/mingw/mingw-on-arch-automator.sh
+++ b/mingw/mingw-on-arch-automator.sh
@@ -121,7 +121,7 @@ EOM
    done
 EOM
   fi
-  makepkg -csi --noconfirm
+  makepkg -csi --noconfirm --force
   if [ "$_AURPKGNAME" == "mingw-w64-winpthreads" ]; then
     libtool --finish /usr/x86_64-w64-mingw32/lib
   fi


### PR DESCRIPTION
To allow rebuilding all packages instead of reusing existing packages from the
previous builds to help prevent possible compiler issues whenever the script is
ran.

[Ticket: none]