### PR TITLE
mingw: pass '-f / --force' argument to makepkg

### DIFF
--- a/mingw/mingw-on-arch-automator.sh
+++ b/mingw/mingw-on-arch-automator.sh
@@ -121,7 +121,11 @@ EOM
    done
 EOM
   fi
-  makepkg -csi --noconfirm --force
+  if [[ "$1" == "-f" ]] || [[ "$1" == "--force" ]]; then
+    makepkg -csi --noconfirm --force
+  else
+    makepkg -csi --noconfirm
+  fi
   if [ "$_AURPKGNAME" == "mingw-w64-winpthreads" ]; then
     libtool --finish /usr/x86_64-w64-mingw32/lib
   fi


### PR DESCRIPTION
better way of doing #355, in my opinion

haven't testing building but should work

well, it's not exactly passing the argument to makepkg but close enough