### PR TITLE
vkd3d: remove staging, add custom repo option

### DIFF
--- a/vkd3d-git/PKGBUILD
+++ b/vkd3d-git/PKGBUILD
@@ -25,9 +25,8 @@ pkgrel=1
 _where=$PWD # track basedir as different Arch based distros are moving srcdir around
 source "$_where"/customization.cfg
 
-if [ "$_vkd3d_source" == "staging" ]; then
-  _vkd3dsrcdir='vkd3d-staging'
-  _vkd3d_source='https://github.com/HansKristian-Work/vkd3d'
+if [ -n "$_vkd3d_source" ]; then
+  _vkd3dsrcdir=$( sed 's|/|-|g' <<< $(sed 's|.*://.[^/]*/||g' <<< $_vkd3d_source))
 else
   _vkd3dsrcdir='vkd3d'
   _vkd3d_source='https://source.winehq.org/git/vkd3d'

--- a/vkd3d-git/customization.cfg
+++ b/vkd3d-git/customization.cfg
@@ -3,7 +3,7 @@
 # custom vkd3d commit to pass to git
 _vkd3d_commit=""
 
-# vkd3d source - leave empty for stock (https://source.winehq.org/git/vkd3d.git) or set to "staging" for https://github.com/HansKristian-Work/vkd3d
+# vkd3d source - leave empty for stock (https://source.winehq.org/git/vkd3d.git), or set a custom repository.
 _vkd3d_source=""
 
 #### USER PATCHES ####


### PR DESCRIPTION
The ['staging' repo](https://github.com/HansKristian-Work/vkd3d) is rarely updated, and not exactly staging in the same sense that wine-staging is. 

Removed this in favour of setting a custom repo, no functional change if you just put in `_vkd3d_source="https://github.com/HansKristian-Work/vkd3d"`