### PR TITLE
wine-tkg-git: Add another use case for _plain_version

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -27,8 +27,10 @@ _init
 _pkgnaming
 
 # custom plain wine commit to pass to git
-if [ "$_use_staging" == "false" ] && [ -n "$_plain_version" ]; then
-  _plain_commit="#commit=$_plain_version"
+if [ -n "$_plain_version" ]; then
+  if [ "$_use_staging" == "false" ] || ( [ "$_use_staging" == "true" ] && [ "$_staging_upstreamignore" == true ] ); then
+    _plain_commit="#commit=$_plain_version"
+  fi
 fi
 
 # custom staging commit to pass to git


### PR DESCRIPTION
Currently if you use the hidden option `_staging_upstreamignore` you're forced to use wine master since `_use_staging` would be true in such a case and thus `_plain_commit`  wouldn't be set.