### PR TITLE
wine-tkg-git: Fix check for staging rawinput commit

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -699,7 +699,7 @@ _prepare() {
 
 	# Proton compatible rawinput patchset
 	if [ "$_proton_rawinput" == "true" ] && [ "$_proton_fs_hack" == "true" ] && [ "$_use_staging" == "true" ]; then
-	  if git merge-base --is-ancestor 6d7828e8df68178ca662bc618f7598254afcfbe1 HEAD; then
+	  if git merge-base --is-ancestor 8218a789558bf074bd26a9adf3bbf05bdb9cb88e HEAD; then
 	    _staging_args+=(-W user32-rawinput-mouse -W user32-rawinput-nolegacy -W user32-rawinput-mouse-experimental -W user32-rawinput-hid -W user32-rawinput-keyboard -W winex11-key_translation)
 	  fi
 	fi


### PR DESCRIPTION
Wine Staging builds earlier than the [Updated rawinput patchsets](https://github.com/wine-staging/wine-staging/commit/8218a789558bf074bd26a9adf3bbf05bdb9cb88e) with `_proton_fs_hack` and `_proton_rawinput` enabled currently fail because the wrong commit is referenced.