### PR TITLE
mesa-git: remove mangohud option

### DIFF
--- a/mesa-git/PKGBUILD
+++ b/mesa-git/PKGBUILD
@@ -226,10 +226,6 @@ prepare() {
 
     cp "$_where"/mesa-userpatches/*.mymesa* "$_where" || true # copy userpatches inside the PKGBUILD's dir
 
-    if [ "$_mangohud" == "true" ]; then
-      wget -O "$_where"/mesa_mangohud.mymesapatch https://github.com/mesa3d/mesa/compare/master...flightlessmango:mango.diff
-    fi
-
     if [ -n "$_mesa_prs" ]; then
       for _pr in ${_mesa_prs[@]}; do
         wget -O "$_where"/"$_pr".mymesapatch https://gitlab.freedesktop.org/mesa/mesa/merge_requests/"$_pr".diff

--- a/mesa-git/customization.cfg
+++ b/mesa-git/customization.cfg
@@ -28,10 +28,6 @@ _localeglpc=false
 # Custom optimization flags - optional
 #_custom_opt_flags="-march=native -O3 -fno-tree-vectorize"
 
-# Flightlessmango hud - https://github.com/flightlessmango/mesa/tree/mango/src/vulkan/overlay-layer
-# Enable with `MANGOHUD=1` envvar
-_mangohud="false"
-
 # Use pending mesa merge requests directly as userpatches with their PR id, separated by space (example: "2421 3151 3273")
 # https://gitlab.freedesktop.org/mesa/mesa/merge_requests
 _mesa_prs=""


### PR DESCRIPTION
MangoHud is now standalone, so the mesa repo is not going to be updated anymore and is pretty far out of date already