### PR TITLE
linux56-rc-tkg: Fix for diffconfig not applying

### DIFF
--- a/linux56-rc-tkg/PKGBUILD
+++ b/linux56-rc-tkg/PKGBUILD
@@ -874,7 +874,7 @@ prepare() {
       if [ -z "$_diffconfig_name" ]; then
         echo 'No file name given, not generating config fragment.'
       else
-        ( cd "$_where"; "${srcdir}/linux-${_basekernel}/scripts/diffconfig" -m "${srcdir}/linux-${_basekernel}/.config.orig" "${srcdir}/linux-${_basekernel}/.config" > "$_diffconfig_name" )
+        ( cd "$_where"; "${srcdir}/linux-${_basekernel}-${_sub}/scripts/diffconfig" -m "${srcdir}/linux-${_basekernel}-${_sub}/.config.orig" "${srcdir}/linux-${_basekernel}-${_sub}}/.config" > "$_diffconfig_name" )
       fi
     fi
     rm .config.orig


### PR DESCRIPTION
I think it happened for 55-rc as well?