### PR TITLE
nvidia-all: Fixes completely broken application profiles

### DIFF
--- a/nvidia-all/PKGBUILD
+++ b/nvidia-all/PKGBUILD
@@ -255,6 +255,11 @@ prepare() {
   if [[ $pkgver = 440.26 ]]; then
     sed -i -e 's|$CC $CFLAGS -c conftest_headers$$.c|LC_ALL=C $CC $CFLAGS -c conftest_headers$$.c|g' kernel/conftest.sh
   fi
+  
+  # 440.58.01 Unfrogging
+  if [[ $pkgver = 440.58.01 ]]; then# 440.58.01 Unfrogging
+    sed -i -e '/bug/d' nvidia-application-profiles-440.58.01-rc
+  fi
 
   cp -a kernel kernel-dkms
   cd kernel-dkms


### PR DESCRIPTION
Without this gnome and other DEs can be unusable