### PR TITLE
wine/proton-tkg: nomakepkg: when parsing the optional first argument …

### DIFF
--- a/proton-tkg/proton-tkg.sh
+++ b/proton-tkg/proton-tkg.sh
@@ -281,7 +281,7 @@ elif [ "$1" == "build_steamhelper" ]; then
 else
   # If $1 contains a path, and it exists, use it as default for config
   if [ -e "$1" ]; then
-    sed -i -e "s|_EXT_CONFIG_PATH.*|_EXT_CONFIG_PATH=$1|" "$_nowhere"/proton-tkg-profiles/advanced-customization.cfg
+    sed -i -e "s|_EXT_CONFIG_PATH.*|_EXT_CONFIG_PATH=$(readlink -m $1)|" "$_nowhere"/proton-tkg-profiles/advanced-customization.cfg
   fi
 
   rm -rf "$_nowhere"/proton_dist_tmp

--- a/wine-tkg-git/non-makepkg-build.sh
+++ b/wine-tkg-git/non-makepkg-build.sh
@@ -246,7 +246,7 @@ elif [ "$1" == "--deps32" ]; then
 else
   # If $1 contains a path, and it exists, use it as default for config
   if [ -e "$1" ]; then
-    sed -i -e "s|_EXT_CONFIG_PATH.*|_EXT_CONFIG_PATH=$1|" "$_where"/wine-tkg-profiles/advanced-customization.cfg
+    sed -i -e "s|_EXT_CONFIG_PATH.*|_EXT_CONFIG_PATH=$(readlink -m $1)|" "$_where"/wine-tkg-profiles/advanced-customization.cfg
   fi
 
   build_wine_tkg


### PR DESCRIPTION
    wine/proton-tkg: nomakepkg: when parsing the optional first argument to these scripts,
    use 'readlink -m' to grab the full path of the input config file. As these scripts want a full
    path, this prevents the config from not being applied if only a partial path is supplied.
    It also follows symbolic links, just in case someone somewhere is using them.

Hopefully the commit description speaks for itself. :frog_ok: